### PR TITLE
Support an optional length argument to ArrayOf

### DIFF
--- a/lib/builtin_contracts.rb
+++ b/lib/builtin_contracts.rb
@@ -260,12 +260,14 @@ module Contracts
   # If it passes for all elements, the contract passes.
   # Example: <tt>ArrayOf[Num]</tt>
   class ArrayOf < CallableClass
-    def initialize(contract)
+    def initialize(contract, length = nil)
       @contract = contract
+      @length = length
     end
 
     def valid?(vals)
       return false unless vals.is_a?(Array)
+      return false if @length && vals.length != @length
       vals.all? do |val|
         res, _ = Contract.valid?(val, @contract)
         res
@@ -273,7 +275,7 @@ module Contracts
     end
 
     def to_s
-      "an array of #{@contract}"
+      (@length ? "a #{@length} element" : "an") + " array of #{@contract}"
     end
 
     def testable?


### PR DESCRIPTION
This lets you specify the array argument to be of a fixed size.

Obviously you could list out each argument but it is a bit cumbersome on my project where the array can be between 5 and 60 required items.

I wonder if there's a better way to do this, but I couldn't see another built-in way and it seems like a common enough use case to include in the core gem.

@egonSchiele if you like this I can update the docs and tests.
