### PR TITLE
Add length check to Array contract

### DIFF
--- a/lib/contracts.rb
+++ b/lib/contracts.rb
@@ -157,7 +157,7 @@ class Contract < Decorator
       # e.g. [Num, String]
       # TODO account for these errors too
       lambda { |arg|
-        return false unless arg.is_a?(Array)
+        return false unless arg.is_a?(Array) && arg.length == contract.length
         arg.zip(contract).all? do |_arg, _contract|
           Contract.valid?(_arg, _contract)
         end


### PR DESCRIPTION
This change causes contracts to fail where the given array is shorter than the array contract. For example the following would have passed previously but will fail after this commit:

```
Contract Num => [Num, Num]
def mult(x)
  [x]
end
```

Fixes #42. (Untested.)
