### PR TITLE
Bug: Eliminates problems with pattern matching with deep contract violations

### DIFF
--- a/lib/contracts.rb
+++ b/lib/contracts.rb
@@ -2,6 +2,15 @@ require 'decorators'
 require 'builtin_contracts'
 
 class ContractError < ArgumentError
+  def to_contract_error
+    self
+  end
+end
+
+class PatternMatchingError < ArgumentError
+  def to_contract_error
+    ContractError.new(to_s)
+  end
 end
 
 module Contracts
@@ -129,7 +138,7 @@ class Contract < Decorator
   #     exit
   #   end
   def self.failure_callback(data)
-    raise ContractError, failure_msg(data)
+    raise data[:contracts].failure_exception, failure_msg(data)
   end
 
   # Used to verify if an argument satisfies a contract.
@@ -248,5 +257,25 @@ class Contract < Decorator
       Contract.failure_callback({:arg => result, :contract => @ret_contract, :class => @klass, :method => @method, :contracts => self, :return_value => true})
     end    
     result
+  end
+
+  def failure_exception
+    pattern_match_exception || regular_exception
+  end
+
+  def pattern_match_exception
+    pattern_match? && PatternMatchingError
+  end
+
+  def regular_exception
+    !pattern_match? && ContractError
+  end
+
+  def pattern_match!
+    @pattern_match = true
+  end
+
+  def pattern_match?
+    !!@pattern_match
   end
 end

--- a/lib/decorators.rb
+++ b/lib/decorators.rb
@@ -119,7 +119,7 @@ Here's why: Suppose you have this code:
         success = false
         i = 0
         result = nil
-        expected_error = methods[0].pattern_match? ? PatternMatchingError : ContractError
+        expected_error = methods[0].failure_exception
         while !success
           method = methods[i]
           i += 1

--- a/lib/decorators.rb
+++ b/lib/decorators.rb
@@ -30,24 +30,32 @@ module MethodDecorators
     # attr_accessor on the class variable decorated_methods
     class << self; attr_accessor :decorated_methods; end
 
-    is_private = nil
+    if is_class_method
+      method_reference = method(name)
+      method_type = :class_methods
+      # private_methods is an array of strings on 1.8 and an array of symbols on 1.9
+      is_private = self.private_methods.include?(name) || self.private_methods.include?(name.to_s)
+    else
+      method_reference = instance_method(name)
+      method_type = :instance_methods
+      # private_instance_methods is an array of strings on 1.8 and an array of symbols on 1.9
+      is_private = self.private_instance_methods.include?(name) || self.private_instance_methods.include?(name.to_s)
+    end
+
+    @decorated_methods[method_type][name] ||= []
+
     decorators.each do |klass, args|
       # a reference to the method gets passed into the contract here. This is good because
       # we are going to redefine this method with a new name below...so this reference is
       # now the *only* reference to the old method that exists.
       # We assume here that the decorator (klass) responds to .new
-      if is_class_method
-        decorator = klass.new(self, method(name), *args)
-        @decorated_methods[:class_methods][name] ||= []
-        @decorated_methods[:class_methods][name] << decorator
-        # private_instance_methods is an array of strings on 1.8 and an array of symbols on 1.9
-        is_private = self.private_methods.include?(name) || self.private_methods.include?(name.to_s)
-      else
-        decorator = klass.new(self, instance_method(name), *args)
-        @decorated_methods[:instance_methods][name] ||= []
-        @decorated_methods[:instance_methods][name] << decorator
-        # private_instance_methods is an array of strings on 1.8 and an array of symbols on 1.9
-        is_private = self.private_instance_methods.include?(name) || self.private_instance_methods.include?(name.to_s)
+      decorator = klass.new(self, method_reference, *args)
+      @decorated_methods[method_type][name] << decorator
+    end
+
+    if @decorated_methods[method_type][name].any? { |x| x.method != method_reference }
+      @decorated_methods[method_type][name].each do |decorator|
+        decorator.pattern_match!
       end
     end
 
@@ -111,15 +119,16 @@ Here's why: Suppose you have this code:
         success = false
         i = 0
         result = nil
+        expected_error = methods[0].pattern_match? ? PatternMatchingError : ContractError
         while !success
           method = methods[i]
           i += 1
           begin
             success = true
             result = method.call_with(self, *args, &blk)
-          rescue ContractError => e
+          rescue expected_error => e
             success = false
-            raise e unless methods[i]
+            raise e.to_contract_error unless methods[i]
           end
         end
         result
@@ -160,5 +169,3 @@ class Decorator
     @method = method
   end
 end
-
-

--- a/spec/contracts_spec.rb
+++ b/spec/contracts_spec.rb
@@ -20,6 +20,29 @@ describe "Contracts:" do
     end
   end
 
+  describe "pattern matching" do
+    let(:string_with_hello) { "Hello, world" }
+    let(:string_without_hello) { "Hi, world" }
+    let(:expected_decorated_string) { "Hello, world!" }
+    subject { PatternMatchingExample.new }
+
+    it "should work as expected when there is no contract violation" do
+      expect(
+        subject.process_request(PatternMatchingExample::Success[string_with_hello])
+      ).to eq(PatternMatchingExample::Success[expected_decorated_string])
+
+      expect(
+        subject.process_request(PatternMatchingExample::Failure.new)
+      ).to be_a(PatternMatchingExample::Failure)
+    end
+
+    it "should not fall through to next pattern when there is a deep contract violation" do
+      expect {
+        subject.process_request(PatternMatchingExample::Success[string_without_hello])
+      }.to raise_error(ContractError)
+    end
+  end
+
   describe "instance methods" do
     it "should allow two classes to have the same method with different contracts" do
       a = A.new

--- a/spec/fixtures/fixtures.rb
+++ b/spec/fixtures/fixtures.rb
@@ -206,3 +206,35 @@ end
 Contract Exactly[Parent] => nil
 def exactly_test(x)
 end
+
+# pattern matching example with possible deep contract violation
+class PatternMatchingExample
+  class Success < Struct.new(:request)
+  end
+
+  class Failure
+  end
+
+  Response = Or[Success, Failure]
+
+  class StringWithHello
+    def self.valid?(string)
+      String === string && !!string.match(/hello/i)
+    end
+  end
+
+  Contract Success => Response
+  def process_request(status)
+    Success[decorated_request(status.request)]
+  end
+
+  Contract Any => Response
+  def process_request(status)
+    Failure.new
+  end
+
+  Contract StringWithHello => String
+  def decorated_request(request)
+    request + "!"
+  end
+end


### PR DESCRIPTION
related to this comment https://github.com/egonSchiele/contracts.ruby/issues/51#issuecomment-68742587

@egonSchiele I have added a fix for deep contract violations when pattern matching. I was able to do that without changing public api (i.e. no additional `Match` keyword or anything like that).