### PR TITLE
Remove explicit date from gemspec

### DIFF
--- a/contracts.gemspec
+++ b/contracts.gemspec
@@ -3,7 +3,6 @@ require File.expand_path(File.join(__FILE__, '../lib/contracts/version'))
 Gem::Specification.new do |s|
   s.name        = "contracts"
   s.version     = Contracts::VERSION
-  s.date        = "2014-05-08"
   s.summary     = "Contracts for Ruby."
   s.description = "This library provides contracts for Ruby. Contracts let you clearly express how your code behaves, and free you from writing tons of boilerplate, defensive code."
   s.author      = "Aditya Bhargava"


### PR DESCRIPTION
It creates very weird history on rubygems if one forget to  update it when releasing new version, like this: https://rubygems.org/gems/contracts

```
0.5 - May 8, 2014 (24.5 KB)
```

even so, it was released recently.

Removing this field from gemspec allows rubygems to automatically set it to current day when releasing.