### PR TITLE
Followup/pull/62 :: Descriptive error when contracts are not included in owner class when used inside of singleton class

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    contracts (0.4)
+    contracts (0.5)
 
 GEM
   remote: http://rubygems.org/

--- a/lib/contracts.rb
+++ b/lib/contracts.rb
@@ -1,65 +1,12 @@
 require 'contracts/core_ext'
 require 'contracts/support'
+require 'contracts/errors'
 require 'contracts/eigenclass'
 require 'contracts/decorators'
 require 'contracts/builtin_contracts'
 require 'contracts/invariants'
 
-# @private
-# Base class for Contract errors
-#
-# If default failure callback is used it stores failure data
-class ContractBaseError < ArgumentError
-  attr_reader :data
-
-  def initialize(message, data)
-    super(message)
-    @data = data
-  end
-
-  # Used to convert to simple ContractError from other contract errors
-  def to_contract_error
-    self
-  end
-end
-
-# Default contract error
-#
-# If default failure callback is used, users normally see only these contract errors
-class ContractError < ContractBaseError
-end
-
-# @private
-# Special contract error used internally to detect pattern failure during pattern matching
-class PatternMatchingError < ContractBaseError
-  # Used to convert to ContractError from PatternMatchingError
-  def to_contract_error
-    ContractError.new(to_s, data)
-  end
-end
-
 module Contracts
-  class ContractsNotIncluded < TypeError
-    DEFAULT_MESSAGE = %{In order to use contracts in singleton class, please include Contracts module in original class
-    Example:
-
-    ```ruby
-    class Example
-      include Contracts  # this line is required
-      class << self
-        # you can use `Contract` definition here now
-      end
-    end
-    ```}
-
-    attr_reader :message
-    alias_method :to_s, :message
-
-    def initialize(message=DEFAULT_MESSAGE)
-      @message = message
-    end
-  end
-
   def self.included(base)
     common base
     eigenclass_common base

--- a/lib/contracts.rb
+++ b/lib/contracts.rb
@@ -39,6 +39,27 @@ class PatternMatchingError < ContractBaseError
 end
 
 module Contracts
+  class ContractsNotIncluded < TypeError
+    DEFAULT_MESSAGE = %{In order to use contracts in singleton class, please include Contracts module in original class
+    Example:
+
+    ```ruby
+    class Example
+      include Contracts  # this line is required
+      class << self
+        # you can use `Contract` definition here now
+      end
+    end
+    ```}
+
+    attr_reader :message
+    alias_method :to_s, :message
+
+    def initialize(message=DEFAULT_MESSAGE)
+      @message = message
+    end
+  end
+
   def self.included(base)
     common base
     eigenclass_common base

--- a/lib/contracts/decorators.rb
+++ b/lib/contracts/decorators.rb
@@ -8,6 +8,22 @@ module Contracts
       end
     end
 
+    module EigenclassWithOwner
+      def self.lift(eigenclass)
+        unless with_owner?(eigenclass)
+          raise Contracts::ContractsNotIncluded
+        end
+
+        eigenclass
+      end
+
+      private
+
+      def self.with_owner?(eigenclass)
+        eigenclass.respond_to?(:owner_class) && eigenclass.owner_class
+      end
+    end
+
     # first, when you write a contract, the decorate method gets called which
     # sets the @decorators variable. Then when the next method after the contract
     # is defined, method_added is called and we look at the @decorators variable
@@ -147,8 +163,7 @@ Here's why: Suppose you have this code:
 
     def decorate(klass, *args)
       if self.singleton_class?
-        raise Contracts::ContractsNotIncluded unless self.respond_to?(:owner_class) && self.owner_class
-        return self.owner_class.decorate(klass, *args)
+        return EigenclassWithOwner.lift(self).owner_class.decorate(klass, *args)
       end
 
       @decorators ||= []

--- a/lib/contracts/decorators.rb
+++ b/lib/contracts/decorators.rb
@@ -147,6 +147,7 @@ Here's why: Suppose you have this code:
 
     def decorate(klass, *args)
       if self.singleton_class?
+        raise Contracts::ContractsNotIncluded unless self.respond_to?(:owner_class) && self.owner_class
         return self.owner_class.decorate(klass, *args)
       end
 

--- a/lib/contracts/errors.rb
+++ b/lib/contracts/errors.rb
@@ -1,0 +1,65 @@
+# @private
+# Base class for Contract errors
+#
+# If default failure callback is used it stores failure data
+class ContractBaseError < ArgumentError
+  attr_reader :data
+
+  def initialize(message, data)
+    super(message)
+    @data = data
+  end
+
+  # Used to convert to simple ContractError from other contract errors
+  def to_contract_error
+    self
+  end
+end
+
+# Default contract error
+#
+# If default failure callback is used, users normally see only these contract errors
+class ContractError < ContractBaseError
+end
+
+# @private
+# Special contract error used internally to detect pattern failure during pattern matching
+class PatternMatchingError < ContractBaseError
+  # Used to convert to ContractError from PatternMatchingError
+  def to_contract_error
+    ContractError.new(to_s, data)
+  end
+end
+
+# Base invariant violation error
+class InvariantError < StandardError
+  def to_contract_error
+    self
+  end
+end
+
+module Contracts
+  # Error issued when user haven't included Contracts in original class but used Contract definition in singleton class
+  #
+  # Provides useful description for user of the gem and an example of correct usage.
+  class ContractsNotIncluded < TypeError
+    DEFAULT_MESSAGE = %{In order to use contracts in singleton class, please include Contracts module in original class
+    Example:
+
+    ```ruby
+    class Example
+      include Contracts  # this line is required
+      class << self
+        # you can use `Contract` definition here now
+      end
+    end
+    ```}
+
+    attr_reader :message
+    alias_method :to_s, :message
+
+    def initialize(message=DEFAULT_MESSAGE)
+      @message = message
+    end
+  end
+end

--- a/lib/contracts/invariants.rb
+++ b/lib/contracts/invariants.rb
@@ -1,9 +1,3 @@
-class InvariantError < StandardError
-  def to_contract_error
-    self
-  end
-end
-
 module Contracts
   module Invariants
     def self.included(base)

--- a/spec/contracts_spec.rb
+++ b/spec/contracts_spec.rb
@@ -83,6 +83,21 @@ RSpec.describe "Contracts:" do
         SingletonClassExample.hoge(3)
       }.to raise_error(ContractError, /Expected: String/)
     end
+
+    context "when owner class does not include Contracts" do
+      it "fails with descriptive error" do
+        expect {
+          Class.new do
+            class << self
+              Contract String => String
+              def hoge(name)
+                "super#{name}"
+              end
+            end
+          end
+        }.to raise_error(Contracts::ContractsNotIncluded, ContractsNotIncluded::DEFAULT_MESSAGE)
+      end
+    end
   end
 
   describe "instance methods" do


### PR DESCRIPTION
followup for #62 

issues descriptive error to not confuse users when they do:

```ruby
require 'contracts'
include Contracts

class X
  class << self
    Contract String => String
    def hoge(name)
      "super#{name}"
    end
  end
end
```

Previously this code failed somewhere with `undefined method on nil:NilClass`, which is totally sets user back wondering what could go wrong.

But now it fails rather nicely:

```
Contracts::ContractsNotIncluded: In order to use contracts in singleton class, please include Contracts module in original class
    Example:

    ```ruby
    class Example
      include Contracts  # this line is required
      class << self
        # you can use `Contract` definition here now
      end
    end
    ```
        ... stacktrace ...
```