### PR TITLE
Bug/66: fix self in inherited singleton methods by changing original method preserving strategy

### DIFF
--- a/lib/contracts.rb
+++ b/lib/contracts.rb
@@ -1,5 +1,6 @@
 require 'contracts/core_ext'
 require 'contracts/support'
+require 'contracts/method_reference'
 require 'contracts/errors'
 require 'contracts/eigenclass'
 require 'contracts/decorators'
@@ -271,13 +272,14 @@ class Contract < Contracts::Decorator
       end
     end
 
-    result = if @method.respond_to? :bind
-      # instance method
-      @method.bind(this).call(*args, &blk)
-    else
-      # class method
+    result = if @method.respond_to?(:call)
+      # proc, block, lambda, etc
       @method.call(*args, &blk)
+    else
+      # original method name referrence
+      @method.send_to(this, *args, &blk)
     end
+
     unless @ret_validator[result]
       Contract.failure_callback({:arg => result, :contract => @ret_contract, :class => @klass, :method => @method, :contracts => self, :return_value => true})
     end

--- a/lib/contracts/decorators.rb
+++ b/lib/contracts/decorators.rb
@@ -47,7 +47,7 @@ module Contracts
       @decorated_methods ||= {:class_methods => {}, :instance_methods => {}}
 
       if is_class_method
-        method_reference = MethodReference.new(name, method(name), true)
+        method_reference = SingletonMethodReference.new(name, method(name))
         method_type = :class_methods
         # private_methods is an array of strings on 1.8 and an array of symbols on 1.9
         is_private = self.private_methods.include?(name) || self.private_methods.include?(name.to_s)

--- a/lib/contracts/decorators.rb
+++ b/lib/contracts/decorators.rb
@@ -34,7 +34,7 @@ module Contracts
       super
     end
 
-    def singleton_method_added name
+    def singleton_method_added(name)
       common_method_added name, true
       super
     end
@@ -47,12 +47,12 @@ module Contracts
       @decorated_methods ||= {:class_methods => {}, :instance_methods => {}}
 
       if is_class_method
-        method_reference = method(name)
+        method_reference = MethodReference.new(name, method(name), true)
         method_type = :class_methods
         # private_methods is an array of strings on 1.8 and an array of symbols on 1.9
         is_private = self.private_methods.include?(name) || self.private_methods.include?(name.to_s)
       else
-        method_reference = instance_method(name)
+        method_reference = MethodReference.new(name, instance_method(name))
         method_type = :instance_methods
         # private_instance_methods is an array of strings on 1.8 and an array of symbols on 1.9
         is_private = self.private_instance_methods.include?(name) || self.private_instance_methods.include?(name.to_s)
@@ -78,6 +78,8 @@ module Contracts
 
         pattern_matching = true
       end
+
+      method_reference.make_alias(self)
 
       return if ENV["NO_CONTRACTS"] && !pattern_matching
 

--- a/lib/contracts/method_reference.rb
+++ b/lib/contracts/method_reference.rb
@@ -1,0 +1,44 @@
+module Contracts
+  class MethodReference
+
+    attr_reader :name
+
+    def initialize(name, method, singleton=false)
+      @name = name
+      @method = method
+      @singleton = singleton
+    end
+
+    def method_position
+      Support.method_position(@method)
+    end
+
+    def make_alias(this)
+      _aliased_name = aliased_name
+      original_name = name
+
+      alias_target(this).class_eval do
+        alias_method _aliased_name, original_name
+      end
+    end
+
+    def send_to(this, *args, &blk)
+      this.send(aliased_name, *args, &blk)
+    end
+
+    private
+
+    def alias_target(this)
+      @singleton ? this.singleton_class : this
+    end
+
+    def aliased_name
+      @_original_name ||= construct_unique_name
+    end
+
+    def construct_unique_name
+      :"__contracts_ruby_original_#{name}_#{Support.unique_id}"
+    end
+
+  end
+end

--- a/lib/contracts/support.rb
+++ b/lib/contracts/support.rb
@@ -2,6 +2,8 @@ module Contracts
   module Support
 
     def self.method_position(method)
+      return method.method_position if MethodReference === method
+
       if RUBY_VERSION =~ /^1\.8/
         if method.respond_to?(:__file__)
           method.__file__ + ":" + method.__line__.to_s
@@ -16,6 +18,15 @@ module Contracts
 
     def self.method_name(method)
       method.is_a?(Proc) ? "Proc" : method.name
+    end
+
+    # Generates unique id, which can be used as a part of identifier
+    #
+    # Example:
+    #    Contracts::Support.unique_id   # => "i53u6tiw5hbo"
+    def self.unique_id
+      # Consider using SecureRandom.hex here, and benchmark which one is better
+      (Time.now.to_f * 1000).to_i.to_s(36) + rand(1000000).to_s(36)
     end
 
   end

--- a/spec/contracts_spec.rb
+++ b/spec/contracts_spec.rb
@@ -121,6 +121,12 @@ RSpec.describe "Contracts:" do
     end
   end
 
+  describe "singleton methods self in inherited methods" do
+    it "should be a proper self" do
+      expect(SingletonInheritanceExampleSubclass.a_contracted_self).to eq(SingletonInheritanceExampleSubclass)
+    end
+  end
+
   describe "instance methods" do
     it "should allow two classes to have the same method with different contracts" do
       a = A.new

--- a/spec/fixtures/fixtures.rb
+++ b/spec/fixtures/fixtures.rb
@@ -331,3 +331,13 @@ with_enabled_no_contracts do
     end
   end
 end
+
+class SingletonInheritanceExample
+  Contract Any => Any
+  def self.a_contracted_self
+    self
+  end
+end
+
+class SingletonInheritanceExampleSubclass < SingletonInheritanceExample
+end


### PR DESCRIPTION
fixes #66 

As I thought, changing to aliasing instead of preserving method object, saves the day. Not only fixes the bug, but improves performance nicely:

master:

```
                                     user     system      total        real
testing add                      0.460000   0.000000   0.460000 (  0.464251)
testing contracts add            4.380000   0.020000   4.400000 (  4.403810)
```

this branch:

```
                                     user     system      total        real
testing add                      0.450000   0.010000   0.460000 (  0.448705)
testing contracts add            3.530000   0.010000   3.540000 (  3.542390)
```

@egonSchiele can you confirm performance improvement?