### PR TITLE
fixes #72: a bit clever handling of splats and blocks combinations

### DIFF
--- a/spec/fixtures/fixtures.rb
+++ b/spec/fixtures/fixtures.rb
@@ -104,6 +104,21 @@ def with_partial_sums(*vals, &blk)
   blk[sum]
 end
 
+Contract Args[Num], Func[Num => Num] => Num
+def with_partial_sums_contracted(*vals, &blk)
+  sum = vals.inject(0) do |acc, val|
+    blk[acc]
+    acc + val
+  end
+  blk[sum]
+end
+
+Contract Num, Proc => nil
+def double_with_proc(x, &blk)
+  blk.call(x * 2)
+  nil
+end
+
 Contract Pos => nil
 def pos_test(x)
 end


### PR DESCRIPTION
fixes #72 
followup to #68 

Now it properly handles different combinations of presence of: splat in contract, proc/func/method in contract and block in arguments.

/cc @egonSchiele 