### PR TITLE
Allow contracts on anonymous classes and modules

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -447,6 +447,7 @@ module M
   def self.parse
     # do some hard parsing
   end
+end
 ```
 
 ## Invariants

--- a/lib/contracts/method_reference.rb
+++ b/lib/contracts/method_reference.rb
@@ -17,6 +17,16 @@ module Contracts
       Support.method_position(@method)
     end
 
+    # Makes a method re-definition in proper way
+    def make_definition(this, &blk)
+      alias_target(this).send(:define_method, name, &blk)
+    end
+
+    # Makes a method private
+    def make_private(this)
+      alias_target(this).class_eval { private name }
+    end
+
     # Aliases original method to a special unique name, which is known
     # only to this class. Usually done right before re-defining the
     # method.

--- a/spec/contracts_spec.rb
+++ b/spec/contracts_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe "Contracts:" do
     end
 
     let(:klass) do
-      Class.new.tap { |klass| klass.include mod }
+      Class.new.tap { |klass| klass.send(:include, mod) }
     end
 
     let(:obj) { klass.new }


### PR DESCRIPTION
Consider these definitions:

```ruby
klass = Class.new do
  include Contracts

  Contract String => nil
  def process(laundry)
    eat(laundry)
  end
end

mod = Module.new do
  include Contracts
  include Contracts::Modules

  Contract String => nil
  def process(laundry)
    eat(laundry)
  end
end
```

They don't work as expected. In fact they fail with undefined method on nil exception. Because the assignment:

```
current = #{self}
ancestors = current.ancestors
```

becomes:

```
current = #<Class:004324234fc>
ancestors = current.ancestors
```

which is equal (since `#` starts one-line comment) to: `current = ancestors = current.ancestors`, in which case, yes, `current` is nil and we try to call `#ancestors` on it, which fails.
To avoid such problems with source-eval solution I have replaced it with ruby block solution, which works great. BTW I have put `self. or not self.` logic where it belongs to - `MethodReference`

Concerning `class_eval method_def, __FILE__, __LINE__ + 1` - file and line could be important but I think they are preserved intact normally when you use blocks, actually this was broken before because line was missed (it was the start of `#decorate` method of this module) when I got errors.

As a bonus small typo fix to tutorial.md.

/cc @egonSchiele 