### PR TITLE
Bug/77 :: fix constant scoping issues

### DIFF
--- a/lib/contracts.rb
+++ b/lib/contracts.rb
@@ -244,11 +244,11 @@ class Contract < Contracts::Decorator
     size = @args_contracts.size
 
     last_contract = @args_contracts.last
-    proc_present = (Func === last_contract ||
+    proc_present = (Contracts::Func === last_contract ||
       (Class === last_contract && (last_contract <= Proc || last_contract <= Method)))
 
     _splat_index = proc_present ? -2 : -1
-    splat_present = Args === @args_contracts[_splat_index]
+    splat_present = Contracts::Args === @args_contracts[_splat_index]
     splat_index = size + _splat_index
     splat_index += 1 unless splat_present
 

--- a/lib/contracts/support.rb
+++ b/lib/contracts/support.rb
@@ -29,5 +29,10 @@ module Contracts
       (Time.now.to_f * 1000).to_i.to_s(36) + rand(1000000).to_s(36)
     end
 
+    def self.eigenclass_hierarchy_supported?
+      return false if RUBY_PLATFORM == "java" && RUBY_VERSION.to_f < 2.0
+      RUBY_VERSION.to_f > 1.8
+    end
+
   end
 end

--- a/spec/builtin_contracts_spec.rb
+++ b/spec/builtin_contracts_spec.rb
@@ -203,11 +203,11 @@ RSpec.describe "Contracts:" do
 
     describe '#to_s' do
       context 'given Symbol => String' do
-        it { expect(HashOf[Symbol, String].to_s).to eq('Hash<Symbol, String>') }
+        it { expect(Contracts::HashOf[Symbol, String].to_s).to eq('Hash<Symbol, String>') }
       end
 
       context 'given String => Num' do
-        it { expect(HashOf[String, Num].to_s).to eq('Hash<String, Contracts::Num>') }
+        it { expect(Contracts::HashOf[String, Contracts::Num].to_s).to eq('Hash<String, Contracts::Num>') }
       end
     end
   end

--- a/spec/builtin_contracts_spec.rb
+++ b/spec/builtin_contracts_spec.rb
@@ -1,8 +1,6 @@
-include Contracts
-
 RSpec.describe "Contracts:" do
   before :all do
-    @o = Object.new
+    @o = GenericExample.new
   end
 
   describe "Num:" do

--- a/spec/contracts_spec.rb
+++ b/spec/contracts_spec.rb
@@ -1,8 +1,6 @@
-include Contracts
-
 RSpec.describe "Contracts:" do
   before :all do
-    @o = Object.new
+    @o = GenericExample.new
   end
 
   describe "basic" do

--- a/spec/contracts_spec.rb
+++ b/spec/contracts_spec.rb
@@ -84,12 +84,13 @@ RSpec.describe "Contracts:" do
 
     context "when owner class does not include Contracts" do
       let(:error) {
-        # NOTE Unable to support this user-friendly error for 1.8.7
-        # it has much less support for singleton inheritance hierarchy
-        if RUBY_VERSION.to_f < 1.9
-          [NoMethodError, /undefined method `Contract'/]
-        else
+        # NOTE Unable to support this user-friendly error for ruby
+        # 1.8.7 and jruby 1.8, 1.9 it has much less support for
+        # singleton inheritance hierarchy
+        if Contracts::Support.eigenclass_hierarchy_supported?
           [Contracts::ContractsNotIncluded, Contracts::ContractsNotIncluded::DEFAULT_MESSAGE]
+        else
+          [NoMethodError, /undefined method `Contract'/]
         end
       }
 

--- a/spec/contracts_spec.rb
+++ b/spec/contracts_spec.rb
@@ -84,8 +84,10 @@ RSpec.describe "Contracts:" do
 
     context "when owner class does not include Contracts" do
       it "fails with descriptive error" do
+        class_with_contracts = Class.new { include Contracts }
+
         expect {
-          Class.new do
+          Class.new(class_with_contracts) do
             class << self
               Contract String => String
               def hoge(name)
@@ -93,7 +95,7 @@ RSpec.describe "Contracts:" do
               end
             end
           end
-        }.to raise_error(Contracts::ContractsNotIncluded, ContractsNotIncluded::DEFAULT_MESSAGE)
+        }.to raise_error(Contracts::ContractsNotIncluded, Contracts::ContractsNotIncluded::DEFAULT_MESSAGE)
       end
     end
   end
@@ -236,11 +238,11 @@ RSpec.describe "Contracts:" do
 
   describe "class methods" do
     it "should pass for correct input" do
-      expect { Object.a_class_method(2) }.to_not raise_error
+      expect { GenericExample.a_class_method(2) }.to_not raise_error
     end
 
     it "should fail for incorrect input" do
-      expect { Object.a_class_method("bad") }.to raise_error(ContractError)
+      expect { GenericExample.a_class_method("bad") }.to raise_error(ContractError)
     end
   end
 

--- a/spec/contracts_spec.rb
+++ b/spec/contracts_spec.rb
@@ -83,11 +83,19 @@ RSpec.describe "Contracts:" do
     end
 
     context "when owner class does not include Contracts" do
-      it "fails with descriptive error" do
-        class_with_contracts = Class.new { include Contracts }
+      let(:error) {
+        # NOTE Unable to support this user-friendly error for 1.8.7
+        # it has much less support for singleton inheritance hierarchy
+        if RUBY_VERSION.to_f < 1.9
+          [NoMethodError, /undefined method `Contract'/]
+        else
+          [Contracts::ContractsNotIncluded, Contracts::ContractsNotIncluded::DEFAULT_MESSAGE]
+        end
+      }
 
+      it "fails with descriptive error" do
         expect {
-          Class.new(class_with_contracts) do
+          Class.new(GenericExample) do
             class << self
               Contract String => String
               def hoge(name)
@@ -95,7 +103,7 @@ RSpec.describe "Contracts:" do
               end
             end
           end
-        }.to raise_error(Contracts::ContractsNotIncluded, Contracts::ContractsNotIncluded::DEFAULT_MESSAGE)
+        }.to raise_error(*error)
       end
     end
   end

--- a/spec/fixtures/fixtures.rb
+++ b/spec/fixtures/fixtures.rb
@@ -54,7 +54,7 @@ class GenericExample
   include Contracts
 
   Contract Num => Num
-  def Object.a_class_method x
+  def GenericExample.a_class_method x
     x + 1
   end
 

--- a/spec/fixtures/fixtures.rb
+++ b/spec/fixtures/fixtures.rb
@@ -1,6 +1,5 @@
-include Contracts
-
 class A
+  include Contracts
 
   Contract Num => Num
   def self.a_class_method x
@@ -28,6 +27,8 @@ class A
 end
 
 class B
+  include Contracts
+
   def bad
     false
   end
@@ -39,6 +40,8 @@ class B
 end
 
 class C
+  include Contracts
+
   def good
     false
   end
@@ -47,170 +50,176 @@ class C
   end
 end
 
-public # we need this otherwise all these methods will automatically be marked private
-Contract Num => Num
-def Object.a_class_method x
-  x + 1
-end
+class GenericExample
+  include Contracts
 
-Contract Num => nil
-def bad_double(x)
-  x * 2
-end
-
-Contract Num => Num
-def double(x)
-  x * 2
-end
-
-Contract String => nil
-def hello(name)
-end
-
-Contract lambda { |x| x.is_a? Numeric } => Num
-def square(x)
-  x ** 2
-end
-
-Contract [Num, Num, Num] => Num
-def sum_three(vals)
-  vals.inject(0) do |acc, x|
-    acc + x
+  Contract Num => Num
+  def Object.a_class_method x
+    x + 1
   end
-end
 
-Contract ({:name => String, :age => Fixnum}) => nil
-def person(data)
-end
-
-Contract Proc => Any
-def do_call(&blk)
-  blk.call
-end
-
-Contract Args[Num] => Num
-def sum(*vals)
-  vals.inject(0) do |acc, val|
-    acc + val
-  end
-end
-
-Contract Args[Num], Proc => Num
-def with_partial_sums(*vals, &blk)
-  sum = vals.inject(0) do |acc, val|
-    blk[acc]
-    acc + val
-  end
-  blk[sum]
-end
-
-Contract Args[Num], Func[Num => Num] => Num
-def with_partial_sums_contracted(*vals, &blk)
-  sum = vals.inject(0) do |acc, val|
-    blk[acc]
-    acc + val
-  end
-  blk[sum]
-end
-
-Contract Num, Proc => nil
-def double_with_proc(x, &blk)
-  blk.call(x * 2)
-  nil
-end
-
-Contract Pos => nil
-def pos_test(x)
-end
-
-Contract Neg => nil
-def neg_test(x)
-end
-
-Contract Any => nil
-def show(x)
-end
-
-Contract None => nil
-def fail_all(x)
-end
-
-Contract Or[Num, String] => nil
-def num_or_string(x)
-end
-
-Contract Xor[RespondTo[:good], RespondTo[:bad]] => nil
-def xor_test(x)
-end
-
-Contract And[A, RespondTo[:good]] => nil
-def and_test(x)
-end
-
-Contract RespondTo[:good] => nil
-def responds_test(x)
-end
-
-Contract Send[:good] => nil
-def send_test(x)
-end
-
-Contract Not[nil] => nil
-def not_nil(x)
-end
-
-Contract ArrayOf[Num] => Num
-def product(vals)
-  vals.inject(1) do |acc, x|
-    acc * x
-  end
-end
-
-Contract Bool => nil
-def bool_test(x)
-end
-
-Contract nil => Num
-def no_args
-  1
-end
-
-Contract ArrayOf[Num], Func[Num => Num] => ArrayOf[Num]
-def map(arr, func)
-  ret = []
-  arr.each do |x|
-    ret << func[x]
-  end
-  ret
-end
-
-Contract Num => Num
-def default_args(x = 1)
-  2
-end
-
-Contract Maybe[Num] => Maybe[Num]
-def maybe_double x
-  if x.nil?
-    nil
-  else
+  Contract Num => nil
+  def bad_double(x)
     x * 2
   end
-end
 
-Contract HashOf[Symbol, Num] => Num
-def gives_max_value(hash)
-  hash.values.max
-end
+  Contract Num => Num
+  def double(x)
+    x * 2
+  end
 
-Contract nil => String
-def a_private_method
-  "works"
+  Contract String => nil
+  def hello(name)
+  end
+
+  Contract lambda { |x| x.is_a? Numeric } => Num
+  def square(x)
+    x ** 2
+  end
+
+  Contract [Num, Num, Num] => Num
+  def sum_three(vals)
+    vals.inject(0) do |acc, x|
+      acc + x
+    end
+  end
+
+  Contract ({:name => String, :age => Fixnum}) => nil
+  def person(data)
+  end
+
+  Contract Proc => Any
+  def do_call(&blk)
+    blk.call
+  end
+
+  Contract Args[Num] => Num
+  def sum(*vals)
+    vals.inject(0) do |acc, val|
+      acc + val
+    end
+  end
+
+  Contract Args[Num], Proc => Num
+  def with_partial_sums(*vals, &blk)
+    sum = vals.inject(0) do |acc, val|
+      blk[acc]
+      acc + val
+    end
+    blk[sum]
+  end
+
+  Contract Args[Num], Func[Num => Num] => Num
+  def with_partial_sums_contracted(*vals, &blk)
+    sum = vals.inject(0) do |acc, val|
+      blk[acc]
+      acc + val
+    end
+    blk[sum]
+  end
+
+  Contract Num, Proc => nil
+  def double_with_proc(x, &blk)
+    blk.call(x * 2)
+    nil
+  end
+
+  Contract Pos => nil
+  def pos_test(x)
+  end
+
+  Contract Neg => nil
+  def neg_test(x)
+  end
+
+  Contract Any => nil
+  def show(x)
+  end
+
+  Contract None => nil
+  def fail_all(x)
+  end
+
+  Contract Or[Num, String] => nil
+  def num_or_string(x)
+  end
+
+  Contract Xor[RespondTo[:good], RespondTo[:bad]] => nil
+  def xor_test(x)
+  end
+
+  Contract And[A, RespondTo[:good]] => nil
+  def and_test(x)
+  end
+
+  Contract RespondTo[:good] => nil
+  def responds_test(x)
+  end
+
+  Contract Send[:good] => nil
+  def send_test(x)
+  end
+
+  Contract Not[nil] => nil
+  def not_nil(x)
+  end
+
+  Contract ArrayOf[Num] => Num
+  def product(vals)
+    vals.inject(1) do |acc, x|
+      acc * x
+    end
+  end
+
+  Contract Bool => nil
+  def bool_test(x)
+  end
+
+  Contract nil => Num
+  def no_args
+    1
+  end
+
+  Contract ArrayOf[Num], Func[Num => Num] => ArrayOf[Num]
+  def map(arr, func)
+    ret = []
+    arr.each do |x|
+      ret << func[x]
+    end
+    ret
+  end
+
+  Contract Num => Num
+  def default_args(x = 1)
+    2
+  end
+
+  Contract Maybe[Num] => Maybe[Num]
+  def maybe_double x
+    if x.nil?
+      nil
+    else
+      x * 2
+    end
+  end
+
+  Contract HashOf[Symbol, Num] => Num
+  def gives_max_value(hash)
+    hash.values.max
+  end
+
+  Contract nil => String
+  def a_private_method
+    "works"
+  end
+  private :a_private_method
+
 end
-private :a_private_method
 
 # for testing inheritance
 class Parent
+  include Contracts
+
   Contract Num => Num
   def double x
     x * 2
@@ -220,17 +229,21 @@ end
 class Child < Parent
 end
 
-Contract Parent => Parent
-def id_ a
-  a
-end
+class GenericExample
+  Contract Parent => Parent
+  def id_ a
+    a
+  end
 
-Contract Exactly[Parent] => nil
-def exactly_test(x)
+  Contract Exactly[Parent] => nil
+  def exactly_test(x)
+  end
 end
 
 # pattern matching example with possible deep contract violation
 class PatternMatchingExample
+  include Contracts
+
   class Success < Struct.new(:request)
   end
 
@@ -315,6 +328,8 @@ end
 
 with_enabled_no_contracts do
   class NoContractsSimpleExample
+    include Contracts
+
     Contract String => nil
     def some_method(x)
       nil
@@ -322,6 +337,7 @@ with_enabled_no_contracts do
   end
 
   class NoContractsInvariantsExample
+    include Contracts
     include Contracts::Invariants
 
     attr_accessor :day
@@ -335,6 +351,8 @@ with_enabled_no_contracts do
   end
 
   class NoContractsPatternMatchingExample
+    include Contracts
+
     Contract 200, String => String
     def on_response(status, body)
       body + "!"
@@ -350,6 +368,7 @@ end
 module ModuleExample
   # This inclusion is required to actually override `method_added`
   # hooks for module.
+  include Contracts
   include Contracts::Modules
 
   Contract Num, Num => Num
@@ -376,6 +395,8 @@ class KlassWithModuleExample
 end
 
 class SingletonInheritanceExample
+  include Contracts
+
   Contract Any => Any
   def self.a_contracted_self
     self

--- a/spec/module_spec.rb
+++ b/spec/module_spec.rb
@@ -1,5 +1,6 @@
 module Mod
   include Contracts
+
   Contract Num => Num
   def self.a_module_method a
      a + 1
@@ -12,6 +13,6 @@ RSpec.describe "module methods" do
   end
 
   it "should fail for incorrect input" do
-    expect { Mod.a_module_method("bad") }.to raise_error
+    expect { Mod.a_module_method("bad") }.to raise_error(ContractError)
   end
 end  


### PR DESCRIPTION
fixes #77 

- Removes global inclusion of `Contracts` in `Object` from specs, so that there is no nasty bugs.