### PR TITLE
Bug/83 :: Builtin contracts are not available on singleton classes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    contracts (0.5)
+    contracts (0.6)
 
 GEM
   remote: http://rubygems.org/

--- a/lib/contracts/eigenclass.rb
+++ b/lib/contracts/eigenclass.rb
@@ -20,6 +20,7 @@ module Contracts
 
       unless eigenclass.respond_to?(:pop_decorators)
         eigenclass.extend(MethodDecorators)
+        eigenclass.include(Contracts)
       end
 
       eigenclass.owner_class = base

--- a/lib/contracts/eigenclass.rb
+++ b/lib/contracts/eigenclass.rb
@@ -20,7 +20,7 @@ module Contracts
 
       unless eigenclass.respond_to?(:pop_decorators)
         eigenclass.extend(MethodDecorators)
-        eigenclass.include(Contracts)
+        eigenclass.send(:include, Contracts)
       end
 
       eigenclass.owner_class = base

--- a/lib/contracts/method_reference.rb
+++ b/lib/contracts/method_reference.rb
@@ -24,7 +24,8 @@ module Contracts
 
     # Makes a method private
     def make_private(this)
-      alias_target(this).class_eval { private name }
+      original_name = name
+      alias_target(this).class_eval { private original_name }
     end
 
     # Aliases original method to a special unique name, which is known

--- a/spec/contracts_spec.rb
+++ b/spec/contracts_spec.rb
@@ -107,6 +107,14 @@ RSpec.describe "Contracts:" do
         }.to raise_error(*error)
       end
     end
+
+    describe "builtin contracts usage" do
+      it "allows to use builtin contracts without namespacing and redundant Contracts inclusion" do
+        expect {
+          SingletonClassExample.add("55", 5.6)
+        }.to raise_error(ContractError, /Expected: Contracts::Num/)
+      end
+    end
   end
 
   describe "no contracts feature" do

--- a/spec/contracts_spec.rb
+++ b/spec/contracts_spec.rb
@@ -449,6 +449,10 @@ RSpec.describe "Contracts:" do
     it "should raise an error if you try to access a private method" do
       expect { @o.a_private_method }.to raise_error
     end
+
+    it "should raise an error if you try to access a private method" do
+      expect { @o.a_really_private_method }.to raise_error
+    end
   end
 
   describe "inherited methods" do

--- a/spec/fixtures/fixtures.rb
+++ b/spec/fixtures/fixtures.rb
@@ -214,6 +214,13 @@ class GenericExample
   end
   private :a_private_method
 
+  private
+
+  Contract nil => String
+  def a_really_private_method
+    "works for sure"
+  end
+
 end
 
 # for testing inheritance

--- a/spec/fixtures/fixtures.rb
+++ b/spec/fixtures/fixtures.rb
@@ -330,6 +330,11 @@ class SingletonClassExample
     def hoge(str)
       "super#{str}"
     end
+
+    Contract Num, Num => Num
+    def add(a, b)
+      a + b
+    end
   end
 end
 


### PR DESCRIPTION
Fixes #83 

During fixing this and while running a benchmark noticed that private methods defined in private section of class can't be defined because of an error, so as well added spec that exposes this and fixed it.

The fix to the original issue is as simple as including `Contracts` while `lift`ing eigenclass to contracted eigenclass.

Touched `Gemfile.lock` since it wasn't updated since last release.