### PR TITLE
Fix indentation in Contracts module documentation

### DIFF
--- a/lib/contracts/builtin_contracts.rb
+++ b/lib/contracts/builtin_contracts.rb
@@ -12,8 +12,8 @@ A simple example:
 
   Contract Num, Num => Num
   def add(a, b)
-     a + b
-   end
+    a + b
+  end
 
 The contract is <tt>Contract Num, Num, Num</tt>. That says that the +add+ function takes two numbers and returns a number.
 =end


### PR DESCRIPTION
You can currently see the problem at http://www.rubydoc.info/gems/contracts/Contracts.