### PR TITLE
Add `Eq` Class for contracts around equality.

### DIFF
--- a/lib/contracts/builtin_contracts.rb
+++ b/lib/contracts/builtin_contracts.rb
@@ -3,7 +3,7 @@ require 'contracts/testable'
 =begin rdoc
 This module contains all the builtin contracts.
 If you want to use them, first:
-  
+
   import Contracts
 
 And then use these or write your own!
@@ -114,7 +114,7 @@ module Contracts
     def testable?
       @vals.all? do |val|
         Testable.testable?(val)
-      end    
+      end
     end
 
     def test_data
@@ -147,19 +147,19 @@ module Contracts
     def testable?
       @vals.all? do |val|
         Testable.testable? val
-      end    
+      end
     end
 
     def test_data
       @vals.map { |val|
         Testable.test_data val
       }.flatten
-    end    
-  end  
+    end
+  end
 
   # Takes a variable number of contracts.
   # The contract passes if all contracts pass.
-  # Example: <tt>And[Fixnum, Float]</tt>  
+  # Example: <tt>And[Fixnum, Float]</tt>
   class And < CallableClass
     def initialize(*vals)
       @vals = vals
@@ -215,7 +215,7 @@ module Contracts
 
     def to_s
       "a value that returns true for all of #{@meths.inspect}"
-    end  
+    end
   end
 
   # Takes a class +A+. If argument is an object of type +A+, the contract passes.
@@ -234,7 +234,24 @@ module Contracts
       "exactly #{@cls.inspect}"
     end
   end
-  
+
+  # Takes a value +v+. If the argument is +.equal+ to +v+, the contract passes,
+  # otherwise the contract fails.
+  # Example: <tt>Eq[Class]</tt>
+  class Eq < CallableClass
+    def initialize(value)
+      @value = value
+    end
+
+    def valid?(val)
+      @value.equal?(val)
+    end
+
+    def to_s
+      "to be equal to #{@value.inspect}"
+    end
+  end
+
   # Takes a variable number of contracts. The contract
   # passes if all of those contracts fail for the given argument.
   # Example: <tt>Not[nil]</tt>
@@ -282,7 +299,7 @@ module Contracts
 
     def test_data
       [[], [Testable.test_data(@contract)], [Testable.test_data(@contract), Testable.test_data(@contract)]]
-    end    
+    end
   end
 
   # Used for <tt>*args</tt> (variadic functions). Takes a contract
@@ -305,7 +322,7 @@ module Contracts
 
     def test_data
       [[], [Testable.test_data(@contract)], [Testable.test_data(@contract), Testable.test_data(@contract)]]
-    end    
+    end
   end
 
   class Bool
@@ -388,7 +405,7 @@ module Contracts
   # Used to define contracts on functions passed in as arguments.
   # Example: <tt>Func[Num => Num] # the function should take a number and return a number</tt>
   class Func < CallableClass
-    attr_reader :contracts    
+    attr_reader :contracts
     def initialize(*contracts)
       @contracts = contracts
     end

--- a/spec/builtin_contracts_spec.rb
+++ b/spec/builtin_contracts_spec.rb
@@ -143,6 +143,28 @@ RSpec.describe "Contracts:" do
     end
   end
 
+  describe "Eq:" do
+    it 'should pass for a class' do
+      expect { @o.eq_class_test(Foo) }
+    end
+
+    it 'should pass for a module' do
+      expect { @o.eq_module_test(Bar) }
+    end
+
+    it 'should pass for other values' do
+      expect { @o.eq_value_test(Baz) }
+    end
+
+    it 'should fail when not equal' do
+      expect { @o.eq_class_test(Bar) }.to raise_error(ContractError)
+    end
+
+    it 'should fail when given instance of class' do
+      expect { @o.eq_class_test(Foo.new) }.to raise_error(ContractError)
+    end
+  end
+
   describe "Not:" do
     it "should pass for an argument that isn't nil" do
       expect { @o.not_nil(1) }.to_not raise_error

--- a/spec/fixtures/fixtures.rb
+++ b/spec/fixtures/fixtures.rb
@@ -259,6 +259,27 @@ class GenericExample
   end
 end
 
+# for testing equality
+class Foo
+end
+module Bar
+end
+Baz = 1
+
+class GenericExample
+  Contract Eq[Foo] => Any
+  def eq_class_test(x)
+  end
+
+  Contract Eq[Bar] => Any
+  def eq_module_test(x)
+  end
+
+  Contract Eq[Baz] => Any
+  def eq_value_test(x)
+  end
+end
+
 # pattern matching example with possible deep contract violation
 class PatternMatchingExample
   include Contracts


### PR DESCRIPTION
Sometimes I'd like to test an argument is equal to a defined set of values. This currently works when I'm dealing with most values, but not when my values are classes.

```ruby
class Foo
  # ...
end

Contract Foo => Any
def foo(arg)
end

foo(Foo.new)  # Works.
foo(Foo)  # Contract error.
```

This adds support for an `Eq` contract, which allows for equality comparison of classes (or anything) using `.equal?`.

```ruby
class Foo
  # ...
end

Contract Eq[Foo] => Any
def foo(arg)
end

foo(Foo.new)  # Contract error.
foo(Foo)  # Works.
```