### PR TITLE
Add `Nat` Contract

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -70,6 +70,7 @@ contracts.ruby comes with a lot of built-in contracts, including the following:
 * [`Num`](http://www.rubydoc.info/gems/contracts/Contracts/Num) – checks that the argument is `Numeric`
 * [`Pos`](http://www.rubydoc.info/gems/contracts/Contracts/Pos) – checks that the argument is a positive number
 * [`Neg`](http://www.rubydoc.info/gems/contracts/Contracts/Neg) – checks that the argument is a negative number
+* [`Nat`](http://www.rubydoc.info/gems/contracts/Contracts/Nat) – checks that the argument is a natural number
 * [`Bool`](http://www.rubydoc.info/gems/contracts/Contracts/Bool) – checks that the argument is `true` or `false`
 * [`Any`](http://www.rubydoc.info/gems/contracts/Contracts/Any) – Passes for any argument. Use when the argument has no constraints.
 * [`None`](http://www.rubydoc.info/gems/contracts/Contracts/None) – Fails for any argument. Use when the method takes no arguments.

--- a/lib/contracts/builtin_contracts.rb
+++ b/lib/contracts/builtin_contracts.rb
@@ -63,6 +63,21 @@ module Contracts
     end
   end
 
+  # Check that an argument is a natural number.
+  class Nat
+    def self.valid? val
+      val >= 0
+    end
+
+    def testable?
+      true
+    end
+
+    def self.test_data
+      (0..5).map { |n| n * rand(999) }
+    end
+  end
+
   # Passes for any argument.
   class Any
     def self.valid? val

--- a/lib/contracts/builtin_contracts.rb
+++ b/lib/contracts/builtin_contracts.rb
@@ -66,7 +66,7 @@ module Contracts
   # Check that an argument is a natural number.
   class Nat
     def self.valid? val
-      val >= 0
+      val >= 0 && val.integer?
     end
 
     def testable?

--- a/spec/builtin_contracts_spec.rb
+++ b/spec/builtin_contracts_spec.rb
@@ -50,8 +50,12 @@ RSpec.describe "Contracts:" do
       expect { @o.nat_test(0) }.to_not raise_error
     end
 
-    it "should pass for positive numbers" do
+    it "should pass for positive whole numbers" do
       expect { @o.nat_test(1) }.to_not raise_error
+    end
+
+    it "should fail for positive non-whole numbers" do
+      expect { @o.nat_test(1.5) }.to raise_error(ContractError)
     end
 
     it "should fail for negative numbers" do

--- a/spec/builtin_contracts_spec.rb
+++ b/spec/builtin_contracts_spec.rb
@@ -45,6 +45,20 @@ RSpec.describe "Contracts:" do
     end
   end
 
+  describe "Nat:" do
+    it "should pass for 0" do
+      expect { @o.nat_test(0) }.to_not raise_error
+    end
+
+    it "should pass for positive numbers" do
+      expect { @o.nat_test(1) }.to_not raise_error
+    end
+
+    it "should fail for negative numbers" do
+      expect { @o.nat_test(-1) }.to raise_error(ContractError)
+    end
+  end
+
   describe "Any:" do
     it "should pass for numbers" do
       expect { @o.show(1) }.to_not raise_error

--- a/spec/builtin_contracts_spec.rb
+++ b/spec/builtin_contracts_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe "Contracts:" do
       expect { @o.pos_test(1) }.to_not raise_error
     end
 
+    it "should fail for 0" do
+      expect { @o.pos_test(0) }.to raise_error(ContractError)
+    end
+
     it "should fail for negative numbers" do
       expect { @o.pos_test(-1) }.to raise_error(ContractError)
     end
@@ -30,6 +34,10 @@ RSpec.describe "Contracts:" do
   describe "Neg:" do
     it "should pass for negative numbers" do
       expect { @o.neg_test(-1) }.to_not raise_error
+    end
+
+    it "should fail for 0" do
+      expect { @o.neg_test(0) }.to raise_error(ContractError)
     end
 
     it "should fail for positive numbers" do

--- a/spec/fixtures/fixtures.rb
+++ b/spec/fixtures/fixtures.rb
@@ -132,6 +132,10 @@ class GenericExample
   def neg_test(x)
   end
 
+  Contract Nat => nil
+  def nat_test(x)
+  end
+
   Contract Any => nil
   def show(x)
   end


### PR DESCRIPTION
Should really have a `Nat` contract, and should make it 100% clear that `Pos` and `Neg` do not include 0.