### PR TITLE
Improved arg validation parsing.

### DIFF
--- a/lib/contracts.rb
+++ b/lib/contracts.rb
@@ -83,10 +83,18 @@ class Contract < Contracts::Decorator
     else
       fail "It looks like your contract for #{method} doesn't have a return value. A contract should be written as `Contract arg1, arg2 => return_value`."
     end
-    @klass, @method= klass, method
-    @has_func_contracts = args_contracts.index do |contract|
-      contract.is_a? Contracts::Func
+    @klass, @method = klass, method
+    @splat_lower_index = @args_contracts.index do |contract|
+      contract.is_a? Contracts::Args
     end
+    last_contract = @args_contracts.last
+    @has_proc_contract = Contracts::Func === last_contract || (
+        Class === last_contract &&
+        (last_contract <= Proc || last_contract <= Method)
+      )
+    penultimate_contract = @args_contracts[-2]
+    @has_options_contract = @has_proc_contract ? Hash === penultimate_contract :
+                                                 Hash === last_contract
   end
 
   def pretty_contract c
@@ -241,61 +249,91 @@ class Contract < Contracts::Decorator
   def call_with(this, *args, &blk)
     _args = blk ? args + [blk] : args
 
-    size = @args_contracts.size
+    args_size = args.size
+    _args_size = _args.size
+    contracts_size = args_contracts.size
 
-    last_contract = @args_contracts.last
-    proc_present = (Contracts::Func === last_contract ||
-      (Class === last_contract && (last_contract <= Proc || last_contract <= Method)))
-
-    _splat_index = proc_present ? -2 : -1
-    splat_present = Contracts::Args === @args_contracts[_splat_index]
-    splat_index = size + _splat_index
-    splat_index += 1 unless splat_present
-
-    # Explicitly append blk=nil if nil != Proc contract violation
-    # anticipated
-    if proc_present && !blk && (splat_present || _args.size < size)
+    # Explicitly append blk=nil if nil != Proc contract violation anticipated
+    if @has_proc_contract && !blk &&
+      (@splat_lower_index || _args_size < contracts_size)
       _args << nil
+      _args_size += 1
     end
 
-    # Size of our iteration is either count of arguments or count of
-    # contracts. Without splat - count of arguments, with splat -
-    # min(count of contracts, count of arguments)
-    _size = _args.size
-    iteration_size = _size
-    iteration_size = size if !splat_present && size < _size
-
-    # check contracts on arguments
-    # fun fact! This is significantly faster than .zip (3.7 secs vs 4.7 secs). Why??
-
-    # times is faster than (0..args.size).each
-    iteration_size.times do |i|
-      # this is done to account for extra args (for *args)
-      j = i > splat_index ? splat_index : i
-      j = size - 1 if i == _size - 1 && proc_present
-      #unless true #@args_contracts[i].valid?(args[i])
-      unless @args_validators[j][_args[i]]
-        call_function = Contract.failure_callback({:arg => _args[i], :contract => @args_contracts[j], :class => @klass, :method => @method, :contracts => self, :arg_pos => i+1, :total_args => _size})
-        return unless call_function
+    # Explicitly append options={} if Hash contract is present
+    if @has_options_contract
+      if @has_proc_contract && Hash === @args_contracts[-2] && !_args[-2].is_a?(Hash)
+        _args.insert(-2, {})
+        _args_size += 1
+      elsif Hash === @args_contracts[-1] && !_args[-1].is_a?(Hash)
+        _args << {}
+        _args_size += 1
       end
     end
 
-    if @has_func_contracts
-      # contracts on methods
-      contracts_size = @args_contracts.size
-      @args_contracts.each_with_index do |contract, i|
-        next if contracts_size - 1 == i && proc_present && blk
+    # Loop forward validating the arguments up to the splat (if there is one)
+    (@splat_lower_index || _args_size).times do |i|
+      _arg = _args[i]
+      contract = @args_contracts[i]
+      validator = @args_validators[i]
+
+
+      unless validator && validator[_arg]
+        return unless Contract.failure_callback({
+          :arg => _arg,
+          :contract => contract,
+          :class => @klass,
+          :method => @method,
+          :contracts => self,
+          :arg_pos => i + 1,
+          :total_args => args_size
+        })
+      end
+
+      if contract.is_a?(Contracts::Func)
+        _args[i] = Contract.new(@klass, _arg, *contract.contracts)
+      end
+    end
+
+    # If there is a splat loop backwards to the lower index of the splat
+    # Once we hit the splat in this direction set its upper index
+    # Keep validating but use this upper index to get the splat validator.
+    if @splat_lower_index
+      splat_upper_index = @splat_lower_index
+      (_args_size - @splat_lower_index).times do |i|
+        _arg = _args[_args_size - 1 - i]
+
+        if Contracts::Args === @args_contracts[contracts_size - 1 - i]
+          splat_upper_index = i
+        end
+
+        # Each arg after the spat is found must use the splat validator
+        j = i < splat_upper_index ? i : splat_upper_index
+        contract = @args_contracts[contracts_size - 1 - j]
+        validator = @args_validators[contracts_size - 1 - j]
+
+        unless validator && validator[_arg]
+          return unless Contract.failure_callback({
+            :arg => _arg,
+            :contract => contract,
+            :class => @klass,
+            :method => @method,
+            :contracts => self,
+            :arg_pos => args_size - i,
+            :total_args => args_size
+          })
+        end
 
         if contract.is_a?(Contracts::Func)
-          args[i] = Contract.new(@klass, args[i], *contract.contracts)
+          _args[_args_size - 1 - i] =
+            Contract.new(@klass, _arg, *contract.contracts)
         end
       end
-
-      if proc_present && blk && last_contract.is_a?(Contracts::Func)
-        blk_contract = Contract.new(@klass, blk, *last_contract.contracts)
-        blk = Proc.new { |*args, &blk| blk_contract.call(*args, &blk) }
-      end
     end
+
+    # If we put the block into _args for validating, restore the args
+    args = _args[0..-2] if blk
+
 
     result = if @method.respond_to?(:call)
       # proc, block, lambda, etc

--- a/spec/contracts_spec.rb
+++ b/spec/contracts_spec.rb
@@ -44,6 +44,16 @@ RSpec.describe "Contracts:" do
       }.to raise_error(ContractError)
     end
 
+    it "should work for differing arities" do
+      expect(
+        subject.do_stuff(1, "abc", 2)
+      ).to eq("bar")
+
+      expect(
+        subject.do_stuff(3, "def")
+      ).to eq("foo")
+    end
+
     context "when failure_callback was overriden" do
       before do
         ::Contract.override_failure_callback do |_data|
@@ -353,6 +363,10 @@ RSpec.describe "Contracts:" do
     it "should fail for incorrect input" do
       expect { @o.sum(1, 2, "bad") }.to raise_error(ContractError)
     end
+
+    it "should work with arg before splat" do
+      expect { @o.arg_then_splat(3, 'hello', 'world') }.to_not raise_error
+    end
   end
 
   describe "varargs with block" do
@@ -372,7 +386,7 @@ RSpec.describe "Contracts:" do
 
       expect {
         @o.with_partial_sums(1, 2, 3, lambda { |x| x })
-      }.to raise_error(ContractError, /Actual: #<Proc/)
+      }.to raise_error(ContractError, /Actual: nil/)
     end
 
     context "when block has Func contract" do
@@ -393,8 +407,20 @@ RSpec.describe "Contracts:" do
       expect { @o.map([1, 2, 3], lambda { |x| x + 1 }) }.to_not raise_error
     end
 
+    it "should pass for a function that passes the contract as in tutorial" do
+      expect { @o.tutorial_map([1, 2, 3], lambda { |x| x + 1 }) }.to_not raise_error
+    end
+
     it "should fail for a function that doesn't pass the contract" do
       expect { @o.map([1, 2, 3], lambda { |x| "bad return value" }) }.to raise_error(ContractError)
+    end
+
+    it "should pass for a function that passes the contract with weak other args" do
+      expect { @o.map_plain(['hello', 'joe'], lambda { |x| x.size }) }.to_not raise_error
+    end
+
+    it "should fail for a function that doesn't pass the contract with weak other args" do
+      expect { @o.map_plain(['hello', 'joe'], lambda { |x| nil }) }.to raise_error(ContractError)
     end
   end
 

--- a/spec/fixtures/fixtures.rb
+++ b/spec/fixtures/fixtures.rb
@@ -118,6 +118,12 @@ class GenericExample
     blk[sum]
   end
 
+  # Important to use different arg types or it falsely passes
+  Contract Num, Args[String] => ArrayOf[String]
+  def arg_then_splat(n, *vals)
+    vals.map{ |v| v * n }
+  end
+
   Contract Num, Proc => nil
   def double_with_proc(x, &blk)
     blk.call(x * 2)
@@ -187,6 +193,24 @@ class GenericExample
       ret << func[x]
     end
     ret
+  end
+
+  Contract ArrayOf[Any], Proc => ArrayOf[Any]
+  def tutorial_map(arr, func)
+    ret = []
+    arr.each do |x|
+      ret << func[x]
+    end
+    ret
+  end
+
+  # Need to test Func with weak contracts for other args
+  # and changing type from input to output otherwise it falsely passes!
+  Contract Array, Func[String => Num] => Array
+  def map_plain(arr, func)
+    arr.map do |x|
+      func[x]
+    end
   end
 
   Contract Num => Num
@@ -311,6 +335,16 @@ class PatternMatchingExample
   Contract StringWithHello => String
   def decorated_request(request)
     request + "!"
+  end
+
+  Contract Num, String => String
+  def do_stuff(number, string)
+    "foo"
+  end
+
+  Contract Num, String, Num => String
+  def do_stuff(number, string, other_number)
+    "bar"
   end
 end
 

--- a/spec/ruby_version_specific/contracts_spec_1.9.rb
+++ b/spec/ruby_version_specific/contracts_spec_1.9.rb
@@ -1,0 +1,22 @@
+class GenericExample
+  Contract Args[String], Num => ArrayOf[String]
+  def splat_then_arg(*vals, n)
+    vals.map{ |v| v * n }
+  end
+end
+
+
+RSpec.describe "Contracts:" do
+  before :all do
+    @o = GenericExample.new
+  end
+
+  describe "Splat not last (or penultimate to block)" do
+    it "should work with arg after splat" do
+      expect { @o.splat_then_arg('hello', 'world', 3) }.to_not raise_error
+    end
+  end
+end
+
+
+

--- a/spec/ruby_version_specific/contracts_spec_2.0.rb
+++ b/spec/ruby_version_specific/contracts_spec_2.0.rb
@@ -1,0 +1,26 @@
+class GenericExample
+ Contract Args[String], { repeat: Maybe[Num] } => ArrayOf[String]
+  def splat_then_optional_named(*vals, repeat: 2)
+    vals.map{ |v| v * repeat }
+  end
+end
+
+
+RSpec.describe "Contracts:" do
+  before :all do
+    @o = GenericExample.new
+  end
+
+  describe "Optional named arguments" do
+    it "should work with optional named argument unfilled after splat" do
+      expect { @o.splat_then_optional_named('hello', 'world') }.to_not raise_error
+    end
+
+    it "should work with optional named argument filled after splat" do
+      expect { @o.splat_then_optional_named('hello', 'world', repeat: 3) }.to_not raise_error
+    end
+  end
+end
+
+
+

--- a/spec/ruby_version_specific/contracts_spec_2.1.rb
+++ b/spec/ruby_version_specific/contracts_spec_2.1.rb
@@ -1,0 +1,56 @@
+class GenericExample
+  Contract String, Bool, Args[Symbol], Float, { e:Range, f:Maybe[Num] }, Proc =>
+           [Proc, Hash, Num, Range, Float, ArrayOf[Symbol], Bool, String]
+  def complicated(a, b=true, *c, d, e:, f:2, **g, &h)
+    h.call [h, g, f, e, d, c, b, a]
+  end
+end
+
+
+RSpec.describe "Contracts:" do
+  before :all do
+    @o = GenericExample.new
+  end
+
+  describe "Required named arguments" do
+    describe "really complicated method signature" do
+      it "should work with default named args used" do
+        expect do
+          @o.complicated('a', false, :b, 2.0, e: (1..5)) { |x| x }
+        end.to_not raise_error
+      end
+
+      it "should work with all args filled manually, with extra splat and hash" do
+        expect do
+          @o.complicated('a', true, :b, :c, 2.0, e: (1..5), f: 8.3, g: :d) {
+            |x| x
+          }
+        end.to_not raise_error
+      end
+
+      it "should fail when the return is invalid" do
+        expect do
+          @o.complicated('a', true, :b, 2.0, e: (1..5)) { |x| 'bad' }
+        end.to raise_error(ContractError)
+      end
+
+      it "should fail when args are invalid" do
+        expect do
+          @o.complicated('a', 'bad', :b, 2.0, e: (1..5)) { |x| x }
+        end.to raise_error(ContractError)
+      end
+
+      it "should fail when splat is invalid" do
+        expect do
+          @o.complicated('a', true, 'bad', 2.0, e: (1..5)) { |x| x }
+        end.to raise_error(ContractError)
+      end
+
+      it "should fail when named argument is invalid" do
+        expect do
+          @o.complicated('a', true, :b, 2.0, e: 'bad') { |x| x }
+        end.to raise_error(ContractError)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,13 @@ require File.expand_path(File.join(__FILE__, "../fixtures/fixtures"))
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  config.pattern = '*.rb'
+
+  # Only load tests who's syntax is valid in the current Ruby
+  [1.9, 2.0, 2.1].each do |ver|
+    config.pattern << ",ruby_version_specific/*#{ver}.rb" if ruby_version >= ver
+  end
+
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.

--- a/spec/support.rb
+++ b/spec/support.rb
@@ -4,3 +4,7 @@ def with_enabled_no_contracts
   yield
   ENV["NO_CONTRACTS"] = no_contracts
 end
+
+def ruby_version
+  RUBY_VERSION.match(/\d+\.\d+/)[0].to_f
+end


### PR DESCRIPTION
Complex method signatures that Ruby allows should now work with Contracts, which fixes #100. Pattern matching with differing arities now works too, which fixes #90. Also fixed some tests that didn't test what they meant to, and added separate test files for syntax only supported by newer Rubies.

## Complex Method Signatures

Before, Contracts made some assumptions about method signatures that were stricter than what Ruby allows. This meant that many methods could not be annotated with Contracts. The problem was assuming that a splat always comes last, when it need not.

I fixed this by looping forwards validating the args up to the splat (or to the end if there isn't one), then looping backwards validating to the splat, then fixing the validator to the splat one and validating any remaining args with that.

This worked, all existing tests pass plus the handful I added. Complex methods such as this now work:

```ruby
  Contract String, Bool, Args[Symbol], Float, { e:Range, f:Maybe[Num] }, Proc =>
           [Proc, Hash, Num, Range, Float, ArrayOf[Symbol], Bool, String]
  def complicated(a, b=true, *c, d, e:, f:2, **g, &h)
    h.call [h, g, f, e, d, c, b, a]
  end
```

## Pattern Matching Different Arities

```ruby
Contract Num, String => String
def do_stuff(number, string)
  "foo"
end

Contract Num, String, Num => String
def do_stuff(number, string, other_number)
  "bar"
end

do_stuff(3, "abc", 4)
=> "bar"
do_stuff(5, "def")
=> "foo"
```


## Speed comparison

Master:

```
                                     user     system      total        real
testing add                      0.310000   0.000000   0.310000 (  0.305342)
testing contracts add            2.950000   0.000000   2.950000 (  2.954473)

#call_with         | 0.027 ms | 0.348 ms | 0.035 ms     | 345.975 ms
```

My modifications:

```
                                     user     system      total        real
testing add                      0.310000   0.000000   0.310000 (  0.311739)
testing contracts add            2.810000   0.000000   2.810000 (  2.812024)

#call_with         | 0.047 ms | 0.478 ms | 0.061 ms     | 607.779 ms
```

So my changes to the `call_with` method seem to have made it almost twice as slow, but overall it has had no noticeable effect on performance.


## Improved Tests

In trying to work out what a 16 line chunk of code did I commented it out and all the tests still passed. However after some manual testing in IRB I figured out what it was for, so I added tests for this before rewriting the arg parsing code. The problem before was having multiple arg validations in one test, so when a test was expecting to raise an exception, it could have been any of the args. Making just the arg validation type being tested a strict validation and the rest `Any` helps fix this. It's also a good idea to change types between args and return to make sure things aren't getting muddled up, e.g. test `Num => String` rather than `Num => Num`.


## Ruby Support

I have tested my modifications all the way back to Ruby 1.8.7 and it still works! The bad news is that Rubies since 1.8.7 introduced new backwards incompatible arg syntax so tests for this new functionality can't be run on old Rubies. 1.9 added the ability for splats to come in places other than the end. 2.0 added required named arguments and doublesplats, 2.1 added optional named arguments. So I have created separate test files for these Ruby version specific tests and they will be run only on supported Rubies according to `RUBY_VERSION`. Travis is happy so it seems to have worked.