### PR TITLE
Improve to_s formatting in error's Expected field.

### DIFF
--- a/lib/contracts.rb
+++ b/lib/contracts.rb
@@ -1,12 +1,13 @@
+require 'contracts/builtin_contracts'
 require 'contracts/core_ext'
-require 'contracts/support'
-require 'contracts/method_reference'
-require 'contracts/errors'
 require 'contracts/decorators'
 require 'contracts/eigenclass'
-require 'contracts/builtin_contracts'
-require 'contracts/modules'
+require 'contracts/errors'
+require 'contracts/formatters'
 require 'contracts/invariants'
+require 'contracts/method_reference'
+require 'contracts/modules'
+require 'contracts/support'
 
 module Contracts
   def self.included(base)
@@ -103,12 +104,7 @@ class Contract < Contracts::Decorator
   # This function is used by the default #failure_callback method
   # and uses the hash passed into the failure_callback method.
   def self.failure_msg(data)
-   expected = if data[:contract].to_s == "" || data[:contract].is_a?(Hash)
-                data[:contract].inspect
-              else
-                data[:contract].to_s
-              end
-
+   expected = Contracts::Formatters::Expected.new(data[:contract]).contract
    position = Contracts::Support.method_position(data[:method])
    method_name = Contracts::Support.method_name(data[:method])
 

--- a/lib/contracts/formatters.rb
+++ b/lib/contracts/formatters.rb
@@ -1,0 +1,69 @@
+module Contracts
+  # A namespace for classes related to formatting.
+  module Formatters
+    # Used to format contracts for the `Expected:` field of error output.
+    class Expected
+      def initialize(contract)
+        @contract = contract
+      end
+
+      # Formats any type of Contract.
+      def contract(contract = @contract)
+        if contract.is_a?(Hash)
+          hash_contract(contract)
+        elsif contract.is_a?(Array)
+          array_contract(contract)
+        else
+          ContractInspectWrapper.new(contract)
+        end
+      end
+
+      # Formats Hash contracts.
+      def hash_contract(hash)
+        hash.inject({}) { |repr, (k, v)|
+          repr.merge(k => ContractInspectWrapper.new(contract(v)))
+        }.inspect
+      end
+
+      # Formats Array contracts.
+      def array_contract(array)
+        array.map{ |v| ContractInspectWrapper.new(contract(v)) }.inspect
+      end
+    end
+
+    # A wrapper class to produce correct inspect behaviour for different
+    # contract values - constants, Class contracts, instance contracts etc.
+    class ContractInspectWrapper
+      def initialize(value)
+        @value = value
+      end
+
+      # Inspect different types of contract values.
+      # Contracts module prefix will be removed from classes.
+      # Custom to_s messages will be wrapped in round brackets to differentiate
+      # from standard Strings.
+      # Primitive values e.g. 42, true, nil will be left alone.
+      def inspect
+        return @value.to_s if plain?
+        return "(#{@value.to_s})" if has_useful_to_s?
+        @value.inspect.gsub(/^Contracts::/, '')
+      end
+
+      # Eliminates eronious quotes in output that plain inspect includes.
+      def to_s
+        inspect
+      end
+
+      private
+      def plain?
+        # Not a type of contract that can have a custom to_s defined
+        !@value.is_a?(CallableClass) && @value.class != Class
+      end
+
+      def has_useful_to_s?
+        # Useless to_s value or no custom to_s behavious defined
+        @value.to_s != "" && @value.to_s != @value.inspect
+      end
+    end
+  end
+end

--- a/spec/fixtures/fixtures.rb
+++ b/spec/fixtures/fixtures.rb
@@ -68,6 +68,11 @@ class GenericExample
     x * 2
   end
 
+  Contract 123, nil => nil
+  def constanty(num, nul)
+    0
+  end
+
   Contract String => nil
   def hello(name)
   end
@@ -84,8 +89,27 @@ class GenericExample
     end
   end
 
-  Contract ({:name => String, :age => Fixnum}) => nil
+  Contract ({ :name => String, :age => Fixnum }) => nil
   def person(data)
+  end
+
+  Contract ({ :rigged => Or[TrueClass, FalseClass] }) => nil
+  def hash_complex_contracts(data)
+  end
+
+  Contract ({ :rigged => Bool,
+              :contents => { :kind => Or[String, Symbol],
+                             :total => Num }
+            }) => nil
+  def nested_hash_complex_contracts(data)
+  end
+
+  Contract [Or[TrueClass, FalseClass]] => nil
+  def array_complex_contracts(data)
+  end
+
+  Contract [Bool, [Or[String, Symbol]]] => nil
+  def nested_array_complex_contracts(data)
   end
 
   Contract Proc => Any


### PR DESCRIPTION
Fixes #108. `to_s` is now called on contracts within Hashes and Arrays.

to_s is recursively called on Hashes and Arrays, so even nested Hashes or Arrays will contain pretty contract representations.

Contracts module prefix is now removed from classes, this makes more sense to me as when you write a contract such as `Contract Num => nil` you'd expect the error to be `Expected: Num` rather than `Expected: Contracts::Num`.

Custom to_s messages will be wrapped in round brackets to differentiate from standard Strings. E.g. `Expected: (a number)`. Without this custom messages get confusing in nested hashes or arrays. Alternatives might be angle brackets (but these get confused with hash rocket syntax) or backticks.

Primitive values e.g. 42, true, nil will be left alone, no erroneous conversion to string.

Tests added for all of these cases. Rebased onto current master. Let me know if you want the coding style changing or want to discus any of the decisions I made.