### PR TITLE
Add initial YARD support

### DIFF
--- a/lib/contracts/formatters.rb
+++ b/lib/contracts/formatters.rb
@@ -5,7 +5,7 @@ module Contracts
     class Expected
       # @param full [Boolean] if false only unique `to_s` values will be output,
       #   non unique values become empty string.
-      def initialize(contract, full=true)
+      def initialize(contract, full = true)
         @contract, @full = contract, full
       end
 
@@ -23,15 +23,15 @@ module Contracts
       # Formats Hash contracts.
       def hash_contract(hash)
         @full = true # Complex values output completely, overriding @full
-        hash.inject({}) { |repr, (k, v)|
+        hash.inject({}) do |repr, (k, v)|
           repr.merge(k => InspectWrapper.new(contract(v), @full))
-        }.inspect
+        end.inspect
       end
 
       # Formats Array contracts.
       def array_contract(array)
         @full = true
-        array.map{ |v| InspectWrapper.new(contract(v), @full) }.inspect
+        array.map { |v| InspectWrapper.new(contract(v), @full) }.inspect
       end
     end
 
@@ -40,7 +40,7 @@ module Contracts
     class InspectWrapper
       # @param full [Boolean] if false only unique `to_s` values will be output,
       #   non unique values become empty string.
-      def initialize(value, full=true)
+      def initialize(value, full = true)
         @value, @full = value, full
       end
 
@@ -53,7 +53,7 @@ module Contracts
         return '' unless full?
         return @value.inspect if empty_val?
         return @value.to_s if plain?
-        return delim(@value.to_s) if has_useful_to_s?
+        return delim(@value.to_s) if useful_to_s?
         @value.inspect.gsub(/^Contracts::/, '')
       end
 
@@ -67,14 +67,15 @@ module Contracts
       end
 
       private
+
       def empty_val?
-        @value.nil? || @value == ""
+        @value.nil? || @value == ''
       end
 
       def full?
         @full ||
-        @value.is_a?(Hash) || @value.is_a?(Array) ||
-        (!plain? && has_useful_to_s?)
+          @value.is_a?(Hash) || @value.is_a?(Array) ||
+          (!plain? && useful_to_s?)
       end
 
       def plain?
@@ -82,10 +83,10 @@ module Contracts
         !@value.is_a?(CallableClass) && @value.class != Class
       end
 
-      def has_useful_to_s?
+      def useful_to_s?
         # Useless to_s value or no custom to_s behavious defined
         # Ruby < 2.0 makes inspect call to_s so this won't work
-        @value.to_s != "" && @value.to_s != @value.inspect
+        @value.to_s != '' && @value.to_s != @value.inspect
       end
     end
   end

--- a/lib/contracts/formatters.rb
+++ b/lib/contracts/formatters.rb
@@ -3,8 +3,10 @@ module Contracts
   module Formatters
     # Used to format contracts for the `Expected:` field of error output.
     class Expected
-      def initialize(contract)
-        @contract = contract
+      # @param full [Boolean] if false only unique `to_s` values will be output,
+      #   non unique values become empty string.
+      def initialize(contract, full=true)
+        @contract, @full = contract, full
       end
 
       # Formats any type of Contract.
@@ -14,28 +16,32 @@ module Contracts
         elsif contract.is_a?(Array)
           array_contract(contract)
         else
-          InspectWrapper.new(contract)
+          InspectWrapper.new(contract, @full)
         end
       end
 
       # Formats Hash contracts.
       def hash_contract(hash)
+        @full = true # Complex values output completely, overriding @full
         hash.inject({}) { |repr, (k, v)|
-          repr.merge(k => InspectWrapper.new(contract(v)))
+          repr.merge(k => InspectWrapper.new(contract(v), @full))
         }.inspect
       end
 
       # Formats Array contracts.
       def array_contract(array)
-        array.map{ |v| InspectWrapper.new(contract(v)) }.inspect
+        @full = true
+        array.map{ |v| InspectWrapper.new(contract(v), @full) }.inspect
       end
     end
 
     # A wrapper class to produce correct inspect behaviour for different
     # contract values - constants, Class contracts, instance contracts etc.
     class InspectWrapper
-      def initialize(value)
-        @value = value
+      # @param full [Boolean] if false only unique `to_s` values will be output,
+      #   non unique values become empty string.
+      def initialize(value, full=true)
+        @value, @full = value, full
       end
 
       # Inspect different types of contract values.
@@ -44,10 +50,15 @@ module Contracts
       # from standard Strings.
       # Primitive values e.g. 42, true, nil will be left alone.
       def inspect
+        return '' unless full?
         return @value.inspect if empty_val?
         return @value.to_s if plain?
-        return "(#{@value.to_s})" if has_useful_to_s?
+        return delim(@value.to_s) if has_useful_to_s?
         @value.inspect.gsub(/^Contracts::/, '')
+      end
+
+      def delim(value)
+        @full ? "(#{value})" : "#{value}"
       end
 
       # Eliminates eronious quotes in output that plain inspect includes.
@@ -60,6 +71,12 @@ module Contracts
         @value.nil? || @value == ""
       end
 
+      def full?
+        @full ||
+        @value.is_a?(Hash) || @value.is_a?(Array) ||
+        (!plain? && has_useful_to_s?)
+      end
+
       def plain?
         # Not a type of contract that can have a custom to_s defined
         !@value.is_a?(CallableClass) && @value.class != Class
@@ -67,6 +84,7 @@ module Contracts
 
       def has_useful_to_s?
         # Useless to_s value or no custom to_s behavious defined
+        # Ruby < 2.0 makes inspect call to_s so this won't work
         @value.to_s != "" && @value.to_s != @value.inspect
       end
     end


### PR DESCRIPTION
YARD documentation generation for Contracts has been made a gem [yard-contracts](https://github.com/sfcgeorge/yard-contracts) Fixes #32 

This pull request adds a minor feature to the Formatters. The new `full` parameter means inspect will output an empty string (when `full=false`) if the `to_s` value would be useless. This is to prevent duplication in yard-contracts; A param docstring is the type (inspect) followed by the description (to_s). Without this patch the type and description can end up being the same which looks odd.

In MRI Ruby < 2 inspect calls to_s so they _always_ are the same. I couldn't find a way to make this work in those old Rubies. JRuby 1.9mode is fine. It doesn't affect the main Contracts gem because when they are the same it calls inspect, but as inspect calls to_s it happens to work as expected.

Currently I have duplicated/overridden this code in yard-contracts so it works for now without this pull request. If you decide to merge then I can take this bit out of yard-contracts.