### PR TITLE
Adit/rubocop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ rvm:
 script:
   - bundle exec rspec
   - ruby rubocop_test.rb
-bundler_args: --without development
+bundler_args: --without development ruby2

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ rvm:
   - jruby-19mode # JRuby in 1.9 mode
 
 script:
-  bundle exec rspec
-  bundle exec rubocop --config rubocop.yml
+  - bundle exec rspec
+  - bundle exec rubocop --config rubocop.yml
 bundler_args: --without development

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,7 @@ rvm:
   - jruby-18mode # JRuby in 1.8 mode
   - jruby-19mode # JRuby in 1.9 mode
 
-script: bundle exec rspec
+script:
+  bundle exec rspec
+  bundle exec rubocop --config rubocop.yml
 bundler_args: --without development

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,5 @@ rvm:
 
 script:
   - bundle exec rspec
-  - bundle exec rubocop --config rubocop.yml
+  - ruby rubocop_test.rb
 bundler_args: --without development

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 group :test do
   gem "rspec"
-  gem "rubocop"
+  gem "rubocop", "~> 0.29"
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,9 @@ gemspec
 
 group :test do
   gem "rspec"
+end
+
+group :ruby2 do
   gem "rubocop", "~> 0.29"
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gemspec
 
 group :test do
   gem "rspec"
+  gem "rubocop"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,5 +45,5 @@ DEPENDENCIES
   contracts!
   method_profiler
   rspec
-  rubocop
+  rubocop (~> 0.29)
   ruby-prof

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,10 +6,17 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
+    ast (2.0.0)
+    astrolabe (1.3.0)
+      parser (>= 2.2.0.pre.3, < 3.0)
     diff-lcs (1.2.5)
     hirb (0.7.2)
     method_profiler (2.0.1)
       hirb (>= 0.6.0)
+    parser (2.2.0.3)
+      ast (>= 1.1, < 3.0)
+    powerpack (0.1.0)
+    rainbow (2.0.0)
     rspec (3.1.0)
       rspec-core (~> 3.1.0)
       rspec-expectations (~> 3.1.0)
@@ -22,7 +29,14 @@ GEM
     rspec-mocks (3.1.3)
       rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
+    rubocop (0.29.1)
+      astrolabe (~> 1.3)
+      parser (>= 2.2.0.1, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.4)
     ruby-prof (0.15.2)
+    ruby-progressbar (1.7.5)
 
 PLATFORMS
   ruby
@@ -31,4 +45,5 @@ DEPENDENCIES
   contracts!
   method_profiler
   rspec
+  rubocop
   ruby-prof

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -536,8 +536,8 @@ class MyBirthday < Struct.new(:day, :month)
   include Contracts
   include Contracts::Invariants
 
-  Invariant(:day) { 1 <= day && day <= 31 }
-  Invariant(:month) { 1 <= month && month <= 12 }
+  invariant(:day) { 1 <= day && day <= 31 }
+  invariant(:month) { 1 <= month && month <= 12 }
 
   Contract None => Fixnum
   def silly_next_day!
@@ -559,7 +559,7 @@ If you run it, last line will generate invariant violation:
    At: main.rb:9
 ```
 
-Which means, that after `#silly_next_day!` all checks specified in `Invariant` statement will be verified, and if at least one fail, then Invariant violation error will be raised.
+Which means, that after `#silly_next_day!` all checks specified in `invariant` statement will be verified, and if at least one fail, then invariant violation error will be raised.
 
 ## Auto-generate documentation using contracts
 

--- a/benchmarks/bench.rb
+++ b/benchmarks/bench.rb
@@ -1,8 +1,8 @@
-require './lib/contracts'
-require 'benchmark'
-require 'rubygems'
-require 'method_profiler'
-require 'ruby-prof'
+require "./lib/contracts"
+require "benchmark"
+require "rubygems"
+require "method_profiler"
+require "ruby-prof"
 
 include Contracts
 
@@ -16,21 +16,21 @@ def contracts_add a, b
 end
 
 def explicit_add a, b
-  raise unless a.is_a?(Numeric)
-  raise unless b.is_a?(Numeric)
+  fail unless a.is_a?(Numeric)
+  fail unless b.is_a?(Numeric)
   c = a + b
-  raise unless c.is_a?(Numeric)
+  fail unless c.is_a?(Numeric)
   c
 end
 
 def benchmark
   Benchmark.bm 30 do |x|
-    x.report 'testing add' do
+    x.report "testing add" do
       1_000_000.times do |_|
         add(rand(1000), rand(1000))
       end
     end
-    x.report 'testing contracts add' do
+    x.report "testing contracts add" do
       1_000_000.times do |_|
         contracts_add(rand(1000), rand(1000))
       end

--- a/benchmarks/bench.rb
+++ b/benchmarks/bench.rb
@@ -26,12 +26,12 @@ end
 def benchmark
   Benchmark.bm 30 do |x|
     x.report 'testing add' do
-      1000000.times do |_|
+      1_000_000.times do |_|
         add(rand(1000), rand(1000))
       end
     end
     x.report 'testing contracts add' do
-      1000000.times do |_|
+      1_000_000.times do |_|
         contracts_add(rand(1000), rand(1000))
       end
     end
@@ -46,20 +46,20 @@ def profile
   profilers << MethodProfiler.observe(Contracts::Decorator)
   profilers << MethodProfiler.observe(Contracts::Support)
   profilers << MethodProfiler.observe(UnboundMethod)
-  10000.times do |_|
+  10_000.times do |_|
     contracts_add(rand(1000), rand(1000))
   end
   profilers.each { |p| puts p.report }
 end
 
 def ruby_prof
-RubyProf.start
-    100000.times do |_|
-      contracts_add(rand(1000), rand(1000))
-    end
-result = RubyProf.stop
-printer = RubyProf::FlatPrinter.new(result)
-printer.print(STDOUT)
+  RubyProf.start
+  100_000.times do |_|
+    contracts_add(rand(1000), rand(1000))
+  end
+  result = RubyProf.stop
+  printer = RubyProf::FlatPrinter.new(result)
+  printer.print(STDOUT)
 end
 
 benchmark

--- a/benchmarks/invariants.rb
+++ b/benchmarks/invariants.rb
@@ -1,8 +1,8 @@
-require './lib/contracts'
-require 'benchmark'
-require 'rubygems'
-require 'method_profiler'
-require 'ruby-prof'
+require "./lib/contracts"
+require "benchmark"
+require "rubygems"
+require "method_profiler"
+require "ruby-prof"
 
 class Obj
   include Contracts
@@ -22,8 +22,8 @@ class ObjWithInvariants
   include Contracts
   include Contracts::Invariants
 
-  Invariant(:value_not_nil) { value != nil }
-  Invariant(:value_not_string) { !value.is_a?(String) }
+  invariant(:value_not_nil) { value != nil }
+  invariant(:value_not_string) { !value.is_a?(String) }
 
   attr_accessor :value
   def initialize value
@@ -41,12 +41,12 @@ def benchmark
   obj_with_invariants = ObjWithInvariants.new(3)
 
   Benchmark.bm 30 do |x|
-    x.report 'testing contracts add' do
+    x.report "testing contracts add" do
       1_000_000.times do |_|
         obj.contracts_add(rand(1000), rand(1000))
       end
     end
-    x.report 'testing contracts add with invariants' do
+    x.report "testing contracts add with invariants" do
       1_000_000.times do |_|
         obj_with_invariants.contracts_add(rand(1000), rand(1000))
       end

--- a/benchmarks/invariants.rb
+++ b/benchmarks/invariants.rb
@@ -4,8 +4,13 @@ require 'rubygems'
 require 'method_profiler'
 require 'ruby-prof'
 
-class Obj < Struct.new(:value)
+class Obj
   include Contracts
+
+  attr_accessor :value
+  def initialize value
+    @value = value
+  end
 
   Contract Num, Num => Num
   def contracts_add a, b
@@ -13,12 +18,17 @@ class Obj < Struct.new(:value)
   end
 end
 
-class ObjWithInvariants < Struct.new(:value)
+class ObjWithInvariants
   include Contracts
   include Contracts::Invariants
 
   Invariant(:value_not_nil) { value != nil }
   Invariant(:value_not_string) { !value.is_a?(String) }
+
+  attr_accessor :value
+  def initialize value
+    @value = value
+  end
 
   Contract Num, Num => Num
   def contracts_add a, b

--- a/benchmarks/invariants.rb
+++ b/benchmarks/invariants.rb
@@ -32,15 +32,15 @@ def benchmark
 
   Benchmark.bm 30 do |x|
     x.report 'testing contracts add' do
-      1000000.times do |_|
+      1_000_000.times do |_|
         obj.contracts_add(rand(1000), rand(1000))
       end
     end
     x.report 'testing contracts add with invariants' do
-      1000000.times do |_|
+      1_000_000.times do |_|
         obj_with_invariants.contracts_add(rand(1000), rand(1000))
       end
-    end  
+    end
   end
 end
 
@@ -55,19 +55,19 @@ def profile
   profilers << MethodProfiler.observe(Contracts::Invariants::InvariantExtension)
   profilers << MethodProfiler.observe(UnboundMethod)
 
-  10000.times do |_|
+  10_000.times do |_|
     obj_with_invariants.contracts_add(rand(1000), rand(1000))
-  end  
+  end
 
   profilers.each { |p| puts p.report }
 end
 
 def ruby_prof
-  RubyProf.start  
+  RubyProf.start
 
   obj_with_invariants = ObjWithInvariants.new(3)
 
-  100000.times do |_|
+  100_000.times do |_|
     obj_with_invariants.contracts_add(rand(1000), rand(1000))
   end
 

--- a/benchmarks/io.rb
+++ b/benchmarks/io.rb
@@ -48,13 +48,13 @@ def profile
 end
 
 def ruby_prof
-RubyProf.start
-    10.times do |_|
-      contracts_download(@urls.sample)
-    end
-result = RubyProf.stop
-printer = RubyProf::FlatPrinter.new(result)
-printer.print(STDOUT)
+  RubyProf.start
+  10.times do |_|
+    contracts_download(@urls.sample)
+  end
+  result = RubyProf.stop
+  printer = RubyProf::FlatPrinter.new(result)
+  printer.print(STDOUT)
 end
 
 benchmark

--- a/benchmarks/io.rb
+++ b/benchmarks/io.rb
@@ -1,9 +1,9 @@
-require './lib/contracts'
-require 'benchmark'
-require 'rubygems'
-require 'method_profiler'
-require 'ruby-prof'
-require 'open-uri'
+require "./lib/contracts"
+require "benchmark"
+require "rubygems"
+require "method_profiler"
+require "ruby-prof"
+require "open-uri"
 
 include Contracts
 
@@ -20,12 +20,12 @@ end
 
 def benchmark
   Benchmark.bm 30 do |x|
-    x.report 'testing download' do
+    x.report "testing download" do
       100.times do |_|
         download(@urls.sample)
       end
     end
-    x.report 'testing contracts download' do
+    x.report "testing contracts download" do
       100.times do |_|
         contracts_download(@urls.sample)
       end

--- a/benchmarks/wrap_test.rb
+++ b/benchmarks/wrap_test.rb
@@ -1,4 +1,4 @@
-require 'benchmark'
+require "benchmark"
 
 module Wrapper
   def self.extended(klass)
@@ -44,12 +44,12 @@ nw = NotWrapped.new
 # exit
 # 30 is the width of the output column
 Benchmark.bm 30 do |x|
-  x.report 'wrapped' do
+  x.report "wrapped" do
     100_000.times do |_|
       w.add(rand(1000), rand(1000))
     end
   end
-  x.report 'not wrapped' do
+  x.report "not wrapped" do
     100_000.times do |_|
       nw.add(rand(1000), rand(1000))
     end

--- a/benchmarks/wrap_test.rb
+++ b/benchmarks/wrap_test.rb
@@ -26,9 +26,9 @@ module Wrapper
 end
 
 class NotWrapped
-def add a, b
-  a + b
-end
+  def add a, b
+    a + b
+  end
 end
 
 class Wrapped
@@ -38,22 +38,20 @@ class Wrapped
   end
 end
 
-
 w = Wrapped.new
 nw = NotWrapped.new
-#p w.add(1, 4)
-#exit
+# p w.add(1, 4)
+# exit
 # 30 is the width of the output column
 Benchmark.bm 30 do |x|
   x.report 'wrapped' do
-    100000.times do |_|
+    100_000.times do |_|
       w.add(rand(1000), rand(1000))
     end
   end
   x.report 'not wrapped' do
-    100000.times do |_|
-      nw.add(rand(1000), rand(1000))      
+    100_000.times do |_|
+      nw.add(rand(1000), rand(1000))
     end
   end
 end
-

--- a/contracts.gemspec
+++ b/contracts.gemspec
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(__FILE__, '../lib/contracts/version'))
+require File.expand_path(File.join(__FILE__, "../lib/contracts/version"))
 
 Gem::Specification.new do |s|
   s.name        = "contracts"

--- a/lib/contracts.rb
+++ b/lib/contracts.rb
@@ -1,13 +1,13 @@
-require 'contracts/builtin_contracts'
-require 'contracts/core_ext'
-require 'contracts/decorators'
-require 'contracts/eigenclass'
-require 'contracts/errors'
-require 'contracts/formatters'
-require 'contracts/invariants'
-require 'contracts/method_reference'
-require 'contracts/modules'
-require 'contracts/support'
+require "contracts/builtin_contracts"
+require "contracts/core_ext"
+require "contracts/decorators"
+require "contracts/eigenclass"
+require "contracts/errors"
+require "contracts/formatters"
+require "contracts/invariants"
+require "contracts/method_reference"
+require "contracts/modules"
+require "contracts/support"
 
 module Contracts
   def self.included(base)
@@ -67,7 +67,7 @@ class Contract < Contracts::Decorator
   # to monkey patch #failure_callback only temporary and then switch it back.
   # First important usage - for specs.
   DEFAULT_FAILURE_CALLBACK = proc do |data|
-    raise data[:contracts].failure_exception.new(failure_msg(data), data)
+    fail data[:contracts].failure_exception.new(failure_msg(data), data)
   end
 
   attr_reader :args_contracts, :ret_contract, :klass, :method
@@ -264,18 +264,17 @@ class Contract < Contracts::Decorator
   # a better way to handle this might be to take this into account
   # before throwing a "mismatched # of args" error.
   def maybe_append_block! args, blk
-    if @has_proc_contract && !blk &&
-       (@args_contract_index || args.size < args_contracts.size)
-      args << nil
-    end
+    return unless @has_proc_contract && !blk &&
+        (@args_contract_index || args.size < args_contracts.size)
+    args << nil
   end
 
   # Same thing for when we have named params but didn't pass any in.
   def maybe_append_options! args, blk
     return unless @has_options_contract
-    if @has_proc_contract && Hash === args_contracts[-2] && !args[-2].is_a?(Hash)
+    if @has_proc_contract && args_contracts[-2].is_a?(Hash) && !args[-2].is_a?(Hash)
       args.insert(-2, {})
-    elsif Hash === args_contracts[-1] && !args[-1].is_a?(Hash)
+    elsif args_contracts[-1].is_a?(Hash) && !args[-1].is_a?(Hash)
       args << {}
     end
   end
@@ -351,7 +350,7 @@ class Contract < Contracts::Decorator
              else
                # original method name referrence
                method.send_to(this, *args, &blk)
-    end
+             end
 
     unless @ret_validator[result]
       Contract.failure_callback(:arg => result,

--- a/lib/contracts.rb
+++ b/lib/contracts.rb
@@ -95,19 +95,19 @@ class Contract < Contracts::Decorator
 
     # == @has_proc_contract
     last_contract = args_contracts.last
-    is_a_proc = Class === last_contract && (last_contract <= Proc || last_contract <= Method)
+    is_a_proc = last_contract.is_a?(Class) && (last_contract <= Proc || last_contract <= Method)
 
-    @has_proc_contract = is_a_proc || Contracts::Func === last_contract
+    @has_proc_contract = is_a_proc || last_contract.is_a?(Contracts::Func)
     # ====
 
     # == @has_options_contract
     last_contract = args_contracts.last
     penultimate_contract = args_contracts[-2]
     @has_options_contract = if @has_proc_contract
-                              Hash === penultimate_contract
+                              penultimate_contract.is_a?(Hash)
                             else
-                              Hash === last_contract
-    end
+                              last_contract.is_a?(Hash)
+                            end
     # ===
 
     @klass, @method = klass, method
@@ -135,7 +135,7 @@ class Contract < Contracts::Decorator
                "Contract violation for return value:"
              else
                "Contract violation for argument #{data[:arg_pos]} of #{data[:total_args]}:"
-    end
+             end
 
     %{#{header}
         Expected: #{expected},
@@ -213,7 +213,7 @@ class Contract < Contracts::Decorator
       contract
     elsif klass == Array
       # e.g. [Num, String]
-      # TODO account for these errors too
+      # TODO: account for these errors too
       lambda do |arg|
         return false unless arg.is_a?(Array) && arg.length == contract.length
         arg.zip(contract).all? do |_arg, _contract|
@@ -318,7 +318,7 @@ class Contract < Contracts::Decorator
       (args.size - @args_contract_index).times do |i|
         arg = args[args.size - 1 - i]
 
-        if Contracts::Args === args_contracts[args_contracts.size - 1 - i]
+        if args_contracts[args_contracts.size - 1 - i].is_a?(Contracts::Args)
           splat_upper_index = i
         end
 

--- a/lib/contracts/builtin_contracts.rb
+++ b/lib/contracts/builtin_contracts.rb
@@ -1,5 +1,5 @@
-require 'contracts/testable'
-require 'contracts/formatters'
+require "contracts/testable"
+require "contracts/formatters"
 
 # rdoc
 # This module contains all the builtin contracts.
@@ -429,7 +429,7 @@ module Contracts
 
     def self.test_data
       # send a random string
-      ('a'..'z').to_a.shuffle[0, 10].join
+      ("a".."z").to_a.shuffle[0, 10].join
     end
   end
 

--- a/lib/contracts/builtin_contracts.rb
+++ b/lib/contracts/builtin_contracts.rb
@@ -16,7 +16,8 @@ require 'contracts/formatters'
 #     a + b
 #   end
 #
-# The contract is <tt>Contract Num, Num, Num</tt>. That says that the +add+ function takes two numbers and returns a number.
+# The contract is <tt>Contract Num, Num, Num</tt>.
+# That says that the +add+ function takes two numbers and returns a number.
 module Contracts
   # Check that an argument is +Numeric+.
   class Num
@@ -123,7 +124,9 @@ module Contracts
     end
 
     def to_s
-      @vals[0, @vals.size-1].map { |x| InspectWrapper.new(x) }.join(", ") + " or " + InspectWrapper.new(@vals[-1]).to_s
+      @vals[0, @vals.size-1].map do |x|
+        InspectWrapper.new(x)
+      end.join(", ") + " or " + InspectWrapper.new(@vals[-1]).to_s
     end
 
     # this can only be tested IF all the sub-contracts have a test_data method
@@ -157,7 +160,9 @@ module Contracts
     end
 
     def to_s
-      @vals[0, @vals.size-1].map { |x| InspectWrapper.new(x) }.join(", ") + " xor " + InspectWrapper.new(@vals[-1]).to_s
+      @vals[0, @vals.size-1].map do |x|
+        InspectWrapper.new(x)
+      end.join(", ") + " xor " + InspectWrapper.new(@vals[-1]).to_s
     end
 
     def testable?
@@ -189,7 +194,9 @@ module Contracts
     end
 
     def to_s
-      @vals[0, @vals.size-1].map { |x| InspectWrapper.new(x) }.join(", ") + " and " + InspectWrapper.new(@vals[-1]).to_s
+      @vals[0, @vals.size-1].map do |x|
+        InspectWrapper.new(x)
+      end.join(", ") + " and " + InspectWrapper.new(@vals[-1]).to_s
     end
   end
 
@@ -234,7 +241,7 @@ module Contracts
     end
   end
 
-  # Takes a class +A+. If argument is an object of type +A+, the contract passes.
+  # Takes a class +A+. If argument is object of type +A+, the contract passes.
   # If it is a subclass of A (or not related to A in any way), it fails.
   # Example: <tt>Exactly[Numeric]</tt>
   class Exactly < CallableClass
@@ -314,7 +321,11 @@ module Contracts
     end
 
     def test_data
-      [[], [Testable.test_data(@contract)], [Testable.test_data(@contract), Testable.test_data(@contract)]]
+      [
+        [],
+        [Testable.test_data(@contract)],
+        [Testable.test_data(@contract), Testable.test_data(@contract)]
+      ]
     end
   end
 
@@ -337,7 +348,11 @@ module Contracts
     end
 
     def test_data
-      [[], [Testable.test_data(@contract)], [Testable.test_data(@contract), Testable.test_data(@contract)]]
+      [
+        [],
+        [Testable.test_data(@contract)],
+        [Testable.test_data(@contract), Testable.test_data(@contract)]
+      ]
     end
   end
 

--- a/lib/contracts/builtin_contracts.rb
+++ b/lib/contracts/builtin_contracts.rb
@@ -1,23 +1,22 @@
 require 'contracts/testable'
 require 'contracts/formatters'
 
-=begin rdoc
-This module contains all the builtin contracts.
-If you want to use them, first:
-
-  import Contracts
-
-And then use these or write your own!
-
-A simple example:
-
-  Contract Num, Num => Num
-  def add(a, b)
-    a + b
-  end
-
-The contract is <tt>Contract Num, Num, Num</tt>. That says that the +add+ function takes two numbers and returns a number.
-=end
+# rdoc
+# This module contains all the builtin contracts.
+# If you want to use them, first:
+#
+#   import Contracts
+#
+# And then use these or write your own!
+#
+# A simple example:
+#
+#   Contract Num, Num => Num
+#   def add(a, b)
+#     a + b
+#   end
+#
+# The contract is <tt>Contract Num, Num, Num</tt>. That says that the +add+ function takes two numbers and returns a number.
 module Contracts
   # Check that an argument is +Numeric+.
   class Num
@@ -30,7 +29,7 @@ module Contracts
     end
 
     def self.test_data
-      [-1, 0, 1, 1.5, 50000]
+      [-1, 0, 1, 1.5, 50_000]
     end
   end
 
@@ -104,7 +103,7 @@ module Contracts
   class CallableClass
     include ::Contracts::Formatters
     def self.[](*vals)
-      self.new(*vals)
+      new(*vals)
     end
   end
 
@@ -135,9 +134,9 @@ module Contracts
     end
 
     def test_data
-      @vals.map { |val|
+      @vals.map do |val|
         Testable.test_data(val)
-      }.flatten
+      end.flatten
     end
   end
 
@@ -168,9 +167,9 @@ module Contracts
     end
 
     def test_data
-      @vals.map { |val|
+      @vals.map do |val|
         Testable.test_data val
-      }.flatten
+      end.flatten
     end
   end
 
@@ -358,14 +357,14 @@ module Contracts
     end
 
     def valid?(hash)
-      keys_match = hash.keys.map {|k| Contract.valid?(k, @key) }.all?
-      vals_match = hash.values.map {|v| Contract.valid?(v, @value) }.all?
+      keys_match = hash.keys.map { |k| Contract.valid?(k, @key) }.all?
+      vals_match = hash.values.map { |v| Contract.valid?(v, @value) }.all?
 
       [keys_match, vals_match].all?
     end
 
     def to_s
-      "Hash<#{@key.to_s}, #{@value.to_s}>"
+      "Hash<#{@key}, #{@value}>"
     end
   end
 
@@ -380,7 +379,7 @@ module Contracts
 
   class ::Hash
     def testable?
-      self.values.all? do |val|
+      values.all? do |val|
         Testable.testable?(val)
       end
     end

--- a/lib/contracts/builtin_contracts.rb
+++ b/lib/contracts/builtin_contracts.rb
@@ -392,46 +392,46 @@ module Contracts
     end
   end
 
-  class ::Hash
-    def testable?
-      values.all? do |val|
-        Testable.testable?(val)
-      end
-    end
+  # class ::Hash
+  #   def testable?
+  #     values.all? do |val|
+  #       Testable.testable?(val)
+  #     end
+  #   end
 
-    def test_data
-      keys = self.keys
-      _vals = keys.map do |key|
-        ret = Testable.test_data(self[key])
-        if ret.is_a? Array
-          ret
-        else
-          [ret]
-        end
-      end
-      all_vals = Testable.product(_vals)
-      hashes = []
-      all_vals.each do |vals|
-        hash = {}
-        keys.zip(vals).each do |key, val|
-          hash[key] = val
-        end
-        hashes << hash
-      end
-      hashes
-    end
-  end
+  #   def test_data
+  #     keys = self.keys
+  #     _vals = keys.map do |key|
+  #       ret = Testable.test_data(self[key])
+  #       if ret.is_a? Array
+  #         ret
+  #       else
+  #         [ret]
+  #       end
+  #     end
+  #     all_vals = Testable.product(_vals)
+  #     hashes = []
+  #     all_vals.each do |vals|
+  #       hash = {}
+  #       keys.zip(vals).each do |key, val|
+  #         hash[key] = val
+  #       end
+  #       hashes << hash
+  #     end
+  #     hashes
+  #   end
+  # end
 
-  class ::String
-    def self.testable?
-      true
-    end
+  # class ::String
+  #   def self.testable?
+  #     true
+  #   end
 
-    def self.test_data
-      # send a random string
-      ("a".."z").to_a.shuffle[0, 10].join
-    end
-  end
+  #   def self.test_data
+  #     # send a random string
+  #     ("a".."z").to_a.shuffle[0, 10].join
+  #   end
+  # end
 
   # Used to define contracts on functions passed in as arguments.
   # Example: <tt>Func[Num => Num] # the function should take a number and return a number</tt>

--- a/lib/contracts/decorators.rb
+++ b/lib/contracts/decorators.rb
@@ -10,9 +10,7 @@ module Contracts
 
     module EigenclassWithOwner
       def self.lift(eigenclass)
-        unless with_owner?(eigenclass)
-          raise Contracts::ContractsNotIncluded
-        end
+        raise Contracts::ContractsNotIncluded unless with_owner?(eigenclass)
 
         eigenclass
       end

--- a/lib/contracts/decorators.rb
+++ b/lib/contracts/decorators.rb
@@ -10,7 +10,7 @@ module Contracts
 
     module EigenclassWithOwner
       def self.lift(eigenclass)
-        raise Contracts::ContractsNotIncluded unless with_owner?(eigenclass)
+        fail Contracts::ContractsNotIncluded unless with_owner?(eigenclass)
 
         eigenclass
       end
@@ -130,7 +130,7 @@ module Contracts
           current = ancestors.shift
         end
         if !current.respond_to?(:decorated_methods) || current.decorated_methods.nil?
-          raise "Couldn't find decorator for method " + self.class.name + ":#{name}.\nDoes this method look correct to you? If you are using contracts from rspec, rspec wraps classes in it's own class.\nLook at the specs for contracts.ruby as an example of how to write contracts in this case."
+          fail "Couldn't find decorator for method " + self.class.name + ":#{name}.\nDoes this method look correct to you? If you are using contracts from rspec, rspec wraps classes in it's own class.\nLook at the specs for contracts.ruby as an example of how to write contracts in this case."
         end
         methods = current.decorated_methods[method_type][name]
 

--- a/lib/contracts/decorators.rb
+++ b/lib/contracts/decorators.rb
@@ -51,7 +51,7 @@ module Contracts
       decorators = fetch_decorators
       return if decorators.empty?
 
-      @decorated_methods ||= {:class_methods => {}, :instance_methods => {}}
+      @decorated_methods ||= { :class_methods => {}, :instance_methods => {} }
 
       if is_class_method
         method_reference = SingletonMethodReference.new(name, method(name))
@@ -75,9 +75,7 @@ module Contracts
       end
 
       if @decorated_methods[method_type][name].any? { |x| x.method != method_reference }
-        @decorated_methods[method_type][name].each do |decorator|
-          decorator.pattern_match!
-        end
+        @decorated_methods[method_type][name].each(&:pattern_match!)
 
         pattern_matching = true
       end
@@ -91,42 +89,40 @@ module Contracts
       # The decorator in turn has a reference to the actual method, so it can call it
       # on its own, after doing it's decorating of course.
 
-=begin
-Very important: THe line `current = #{self}` in the start is crucial.
-Not having it means that any method that used contracts could NOT use `super`
-(see this issue for example: https://github.com/egonSchiele/contracts.ruby/issues/27).
-Here's why: Suppose you have this code:
-
-    class Foo
-      Contract nil => String
-      def to_s
-        "Foo"
-      end
-    end
-
-    class Bar < Foo
-      Contract nil => String
-      def to_s
-        super + "Bar"
-      end
-    end
-
-    b = Bar.new
-    p b.to_s
-
-    `to_s` in Bar calls `super`. So you expect this to call `Foo`'s to_s. However,
-    we have overwritten the function (that's what this next defn is). So it gets a
-    reference to the function to call by looking at `decorated_methods`.
-
-    Now, this line used to read something like:
-
-      current = self#{is_class_method ? "" : ".class"}
-
-    In that case, `self` would always be `Bar`, regardless of whether you were calling
-    Foo's to_s or Bar's to_s. So you would keep getting Bar's decorated_methods, which
-    means you would always call Bar's to_s...infinite recursion! Instead, you want to
-    call Foo's version of decorated_methods. So the line needs to be `current = #{self}`.
-=end
+      # Very important: THe line `current = #{self}` in the start is crucial.
+      # Not having it means that any method that used contracts could NOT use `super`
+      # (see this issue for example: https://github.com/egonSchiele/contracts.ruby/issues/27).
+      # Here's why: Suppose you have this code:
+      #
+      #     class Foo
+      #       Contract nil => String
+      #       def to_s
+      #         "Foo"
+      #       end
+      #     end
+      #
+      #     class Bar < Foo
+      #       Contract nil => String
+      #       def to_s
+      #         super + "Bar"
+      #       end
+      #     end
+      #
+      #     b = Bar.new
+      #     p b.to_s
+      #
+      #     `to_s` in Bar calls `super`. So you expect this to call `Foo`'s to_s. However,
+      #     we have overwritten the function (that's what this next defn is). So it gets a
+      #     reference to the function to call by looking at `decorated_methods`.
+      #
+      #     Now, this line used to read something like:
+      #
+      #       current = self#{is_class_method ? "" : ".class"}
+      #
+      #     In that case, `self` would always be `Bar`, regardless of whether you were calling
+      #     Foo's to_s or Bar's to_s. So you would keep getting Bar's decorated_methods, which
+      #     means you would always call Bar's to_s...infinite recursion! Instead, you want to
+      #     call Foo's version of decorated_methods. So the line needs to be `current = #{self}`.
 
       current = self
       method_reference.make_definition(self) do |*args, &blk|
@@ -147,7 +143,7 @@ Here's why: Suppose you have this code:
         i = 0
         result = nil
         expected_error = methods[0].failure_exception
-        while !success
+        until success
           method = methods[i]
           i += 1
           begin
@@ -183,7 +179,7 @@ Here's why: Suppose you have this code:
     class << self; attr_accessor :decorators; end
 
     def self.inherited(klass)
-      name = klass.name.gsub(/^./) {|m| m.downcase}
+      name = klass.name.gsub(/^./) { |m| m.downcase }
 
       return if name =~ /^[^A-Za-z_]/ || name =~ /[^0-9A-Za-z_]/
 

--- a/lib/contracts/eigenclass.rb
+++ b/lib/contracts/eigenclass.rb
@@ -1,6 +1,5 @@
 module Contracts
   module Eigenclass
-
     def self.extended(eigenclass)
       return if eigenclass.respond_to?(:owner_class=)
 
@@ -37,6 +36,5 @@ module Contracts
         []
       end
     end
-
   end
 end

--- a/lib/contracts/eigenclass.rb
+++ b/lib/contracts/eigenclass.rb
@@ -13,9 +13,7 @@ module Contracts
 
       eigenclass = base.singleton_class
 
-      unless eigenclass.respond_to?(:owner_class=)
-        eigenclass.extend(Eigenclass)
-      end
+      eigenclass.extend(Eigenclass) unless eigenclass.respond_to?(:owner_class=)
 
       unless eigenclass.respond_to?(:pop_decorators)
         eigenclass.extend(MethodDecorators)

--- a/lib/contracts/errors.rb
+++ b/lib/contracts/errors.rb
@@ -58,7 +58,7 @@ module Contracts
     attr_reader :message
     alias_method :to_s, :message
 
-    def initialize(message=DEFAULT_MESSAGE)
+    def initialize(message = DEFAULT_MESSAGE)
       @message = message
     end
   end

--- a/lib/contracts/formatters.rb
+++ b/lib/contracts/formatters.rb
@@ -20,14 +20,14 @@ module Contracts
 
       # Formats Hash contracts.
       def hash_contract(hash)
-        hash.inject({}) { |repr, (k, v)|
+        hash.inject({}) do |repr, (k, v)|
           repr.merge(k => InspectWrapper.new(contract(v)))
-        }.inspect
+        end.inspect
       end
 
       # Formats Array contracts.
       def array_contract(array)
-        array.map{ |v| InspectWrapper.new(contract(v)) }.inspect
+        array.map { |v| InspectWrapper.new(contract(v)) }.inspect
       end
     end
 
@@ -46,7 +46,7 @@ module Contracts
       def inspect
         return @value.inspect if empty_val?
         return @value.to_s if plain?
-        return "(#{@value.to_s})" if has_useful_to_s?
+        return "(#{@value})" if has_useful_to_s?
         @value.inspect.gsub(/^Contracts::/, '')
       end
 
@@ -56,6 +56,7 @@ module Contracts
       end
 
       private
+
       def empty_val?
         @value.nil? || @value == ""
       end

--- a/lib/contracts/formatters.rb
+++ b/lib/contracts/formatters.rb
@@ -50,11 +50,11 @@ module Contracts
       # from standard Strings.
       # Primitive values e.g. 42, true, nil will be left alone.
       def inspect
-        return '' unless full?
+        return "" unless full?
         return @value.inspect if empty_val?
         return @value.to_s if plain?
         return delim(@value.to_s) if useful_to_s?
-        @value.inspect.gsub(/^Contracts::/, '')
+        @value.inspect.gsub(/^Contracts::/, "")
       end
 
       def delim(value)
@@ -69,7 +69,7 @@ module Contracts
       private
 
       def empty_val?
-        @value.nil? || @value == ''
+        @value.nil? || @value == ""
       end
 
       def full?
@@ -86,7 +86,7 @@ module Contracts
       def useful_to_s?
         # Useless to_s value or no custom to_s behavious defined
         # Ruby < 2.0 makes inspect call to_s so this won't work
-        @value.to_s != '' && @value.to_s != @value.inspect
+        @value.to_s != "" && @value.to_s != @value.inspect
       end
     end
   end

--- a/lib/contracts/invariants.rb
+++ b/lib/contracts/invariants.rb
@@ -23,7 +23,7 @@ module Contracts
     end
 
     module InvariantExtension
-      def Invariant(name, &condition)
+      def invariant(name, &condition)
         return if ENV["NO_CONTRACTS"]
 
         invariants << Invariant.new(self, name, &condition)
@@ -53,7 +53,7 @@ module Contracts
       end
 
       def self.failure_callback(data)
-        raise InvariantError, failure_msg(data)
+        fail InvariantError, failure_msg(data)
       end
 
       def self.failure_msg(data)

--- a/lib/contracts/invariants.rb
+++ b/lib/contracts/invariants.rb
@@ -57,13 +57,12 @@ module Contracts
       end
 
       def self.failure_msg(data)
-%{Invariant violation:
-    Expected: #{data[:expected]}
-    Actual: #{data[:actual]}
-    Value guarded in: #{data[:target].class}::#{Support.method_name(data[:method])}
-    At: #{Support.method_position(data[:method])}}
+        %{Invariant violation:
+            Expected: #{data[:expected]}
+            Actual: #{data[:actual]}
+            Value guarded in: #{data[:target].class}::#{Support.method_name(data[:method])}
+            At: #{Support.method_position(data[:method])}}
       end
     end
-
   end
 end

--- a/lib/contracts/method_reference.rb
+++ b/lib/contracts/method_reference.rb
@@ -2,7 +2,6 @@ module Contracts
   # MethodReference represents original method reference that was
   # decorated by contracts.ruby. Used for instance methods.
   class MethodReference
-
     attr_reader :name
 
     # name - name of the method
@@ -79,7 +78,6 @@ module Contracts
     def construct_unique_name
       :"__contracts_ruby_original_#{name}_#{Support.unique_id}"
     end
-
   end
 
   # The same as MethodReference, but used for singleton methods.

--- a/lib/contracts/support.rb
+++ b/lib/contracts/support.rb
@@ -1,6 +1,5 @@
 module Contracts
   module Support
-
     def self.method_position(method)
       return method.method_position if MethodReference === method
 
@@ -26,13 +25,12 @@ module Contracts
     #    Contracts::Support.unique_id   # => "i53u6tiw5hbo"
     def self.unique_id
       # Consider using SecureRandom.hex here, and benchmark which one is better
-      (Time.now.to_f * 1000).to_i.to_s(36) + rand(1000000).to_s(36)
+      (Time.now.to_f * 1000).to_i.to_s(36) + rand(1_000_000).to_s(36)
     end
 
     def self.eigenclass_hierarchy_supported?
       return false if RUBY_PLATFORM == "java" && RUBY_VERSION.to_f < 2.0
       RUBY_VERSION.to_f > 1.8
     end
-
   end
 end

--- a/lib/contracts/support.rb
+++ b/lib/contracts/support.rb
@@ -1,7 +1,7 @@
 module Contracts
   module Support
     def self.method_position(method)
-      return method.method_position if MethodReference === method
+      return method.method_position if method.is_a?(MethodReference)
 
       if RUBY_VERSION =~ /^1\.8/
         if method.respond_to?(:__file__)

--- a/lib/contracts/testable.rb
+++ b/lib/contracts/testable.rb
@@ -30,7 +30,7 @@ module Contracts
       end
     end
 
-    # TODO Should work on whatever class it was invoked on, no?
+    # TODO: Should work on whatever class it was invoked on, no?
     def self.check_all
       o = Object.new
       Object.decorated_methods.each do |name, _contracts|

--- a/lib/contracts/testable.rb
+++ b/lib/contracts/testable.rb
@@ -7,11 +7,11 @@ module Contracts
     #
     #   [[1, 3], [1, 4], [2, 3], [2, 4]]
     def self.product(arrays)
-      arrays.inject { |acc, x|
+      arrays.inject do |acc, x|
         acc.product(x)
-      }.flatten(arrays.size - 2)
+      end.flatten(arrays.size - 2)
     end
-    
+
     # Given a contract, tells if you it's testable
     def self.testable?(contract)
       if contract.respond_to?(:testable?)
@@ -33,7 +33,7 @@ module Contracts
     # TODO Should work on whatever class it was invoked on, no?
     def self.check_all
       o = Object.new
-      Object.decorated_methods.each do |name, contracts|
+      Object.decorated_methods.each do |name, _contracts|
         check(o.method(name))
       end
     end
@@ -64,6 +64,6 @@ module Contracts
         end
         puts "#{test_data.size} tests run."
       end
-    end    
+    end
   end
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,0 +1,33 @@
+Style/MethodDefParentheses:
+  Enabled: false
+
+# not my preference -- I prefer "" to '' always
+Style/StringLiterals:
+  Enabled: false
+
+Style/SignalException:
+  Enabled: false
+
+Style/NonNilCheck:
+  Enabled: false
+
+Style/PercentLiteralDelimiters:
+  Enabled: false
+
+# not compatible with ruby 1.8
+Style/Lambda:
+  Enabled: false
+
+# not compatible with ruby 1.8
+Style/HashSyntax:
+  Enabled: false
+
+# we use unused method args a lot in tests/fixtures (a quirk of this lib)
+Lint/UnusedMethodArgument:
+  Enabled: false
+
+Style/SpaceAroundOperators:
+  Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,12 +1,8 @@
 Style/MethodDefParentheses:
   Enabled: false
 
-# not my preference -- I prefer "" to '' always
 Style/StringLiterals:
-  Enabled: false
-
-Style/SignalException:
-  Enabled: false
+  EnforcedStyle: double_quotes
 
 Style/NonNilCheck:
   Enabled: false
@@ -48,3 +44,32 @@ Style/ClassAndModuleChildren:
 # triggered by Contract ({ :name => String, :age => Fixnum }) => nil
 Lint/ParenthesesAsGroupedExpression:
   Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Metrics/BlockNesting:
+  Enabled: false
+
+Style/ClassVars:
+  Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
+
+Metrics/PerceivedComplexity:
+  Enabled: false
+
+# contracts provides this functionality
+Lint/DuplicateMethods:
+  Enabled: false
+
+# noisy cop with false positives
+Style/TrivialAccessors:
+  Enabled: false
+
+Style/MultilineOperationIndentation:
+  EnforcedStyle: indented

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -29,5 +29,22 @@ Lint/UnusedMethodArgument:
 Style/SpaceAroundOperators:
   Enabled: false
 
+Lint/UnderscorePrefixedVariableName:
+  Enabled: false
+
 Metrics/MethodLength:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Metrics/LineLength:
+  Enabled: false
+
+# getting triggered by "::String"
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+# triggered by Contract ({ :name => String, :age => Fixnum }) => nil
+Lint/ParenthesesAsGroupedExpression:
   Enabled: false

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,19 +1,24 @@
+# forces method defs to have params in parens
 Style/MethodDefParentheses:
   Enabled: false
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
+# changes x != nil to !x.nil?
 Style/NonNilCheck:
   Enabled: false
 
+# changes %{} to %()
 Style/PercentLiteralDelimiters:
   Enabled: false
 
+# changes lambdas to ruby 1.9-style ->
 # not compatible with ruby 1.8
 Style/Lambda:
   Enabled: false
 
+# changes to new hash syntax
 # not compatible with ruby 1.8
 Style/HashSyntax:
   Enabled: false
@@ -22,54 +27,96 @@ Style/HashSyntax:
 Lint/UnusedMethodArgument:
   Enabled: false
 
+# changes x ** 2 to x**2
 Style/SpaceAroundOperators:
   Enabled: false
 
+# doesn't allow vars starting with _
 Lint/UnderscorePrefixedVariableName:
   Enabled: false
 
+# enforces method length of 10 lines
 Metrics/MethodLength:
   Enabled: false
 
+# forces you to document classes
+# TODO: try to enable this cop
 Style/Documentation:
   Enabled: false
 
+# enforces line length of 80
 Metrics/LineLength:
-  Enabled: false
-
-# getting triggered by "::String"
-Style/ClassAndModuleChildren:
   Enabled: false
 
 # triggered by Contract ({ :name => String, :age => Fixnum }) => nil
 Lint/ParenthesesAsGroupedExpression:
   Enabled: false
 
+# checks how much a method branches.
+# TODO try to get this cop enabled
 Metrics/AbcSize:
   Enabled: false
 
+# checks complexity of method
+# TODO try to get this cop enabled
 Metrics/CyclomaticComplexity:
   Enabled: false
 
+# checks for too many nested ifs, whiles or rescues (but not too many nested blocks)
+# TODO: try to get this cop enabled eventually
 Metrics/BlockNesting:
   Enabled: false
 
+# calls out class variables.
+# TODO: try to get this cop enabled eventually
 Style/ClassVars:
   Enabled: false
 
+# enforces class length of < 100 lines
 Metrics/ClassLength:
   Enabled: false
 
+# TODO: try to get this cop enabled eventually
 Metrics/PerceivedComplexity:
   Enabled: false
 
-# contracts provides this functionality
+# checks for duplicate methods, but contracts
+# provides this functionality (multi-dispatch)
 Lint/DuplicateMethods:
   Enabled: false
 
-# noisy cop with false positives
+# checks to see if you could've used attr_accessor instead.
+# nice in theory but noisy cop with false positives
 Style/TrivialAccessors:
   Enabled: false
 
 Style/MultilineOperationIndentation:
   EnforcedStyle: indented
+
+# Asks you to use %w{array of words} if possible.
+# Not a style I like.
+Style/WordArray:
+  Enabled: false
+
+# conflicts with contracts
+# we define contracts like `Baz = 1`
+Style/ConstantName:
+  Enabled: false
+
+# `Contract` violates this, otherwise a good cop (enforces snake_case method names)
+# TODO possible to get this enabled but ignore `Contract`?
+Style/MethodName:
+  Enabled: false
+
+# checks for !!
+Style/DoubleNegation:
+  Enabled: false
+
+# enforces < 5 params for a function.
+# contracts-specific (long parameter list for test)
+Metrics/ParameterLists:
+  Enabled: false
+
+# Checks that braces used for hash literals have or don't have surrounding space depending on configuration.
+Style/SpaceInsideHashLiteralBraces:
+  Enabled: false

--- a/rubocop_test.rb
+++ b/rubocop_test.rb
@@ -1,0 +1,3 @@
+if RUBY_VERSION =~ /^2.1/
+  puts `bundle exec rubocop --config rubocop.yml #{ARGV.join(" ")}`
+end

--- a/rubocop_test.rb
+++ b/rubocop_test.rb
@@ -1,3 +1,3 @@
 if RUBY_VERSION =~ /^2.1/
-  puts `bundle exec rubocop --config rubocop.yml #{ARGV.join(" ")}`
+  puts `bundle && bundle exec rubocop --config rubocop.yml #{ARGV.join(" ")}`
 end

--- a/spec/builtin_contracts_spec.rb
+++ b/spec/builtin_contracts_spec.rb
@@ -170,23 +170,23 @@ RSpec.describe "Contracts:" do
   end
 
   describe "Eq:" do
-    it 'should pass for a class' do
+    it "should pass for a class" do
       expect { @o.eq_class_test(Foo) }
     end
 
-    it 'should pass for a module' do
+    it "should pass for a module" do
       expect { @o.eq_module_test(Bar) }
     end
 
-    it 'should pass for other values' do
+    it "should pass for other values" do
       expect { @o.eq_value_test(Baz) }
     end
 
-    it 'should fail when not equal' do
+    it "should fail when not equal" do
       expect { @o.eq_class_test(Bar) }.to raise_error(ContractError)
     end
 
-    it 'should fail when given instance of class' do
+    it "should fail when given instance of class" do
       expect { @o.eq_class_test(Foo.new) }.to raise_error(ContractError)
     end
   end
@@ -240,22 +240,22 @@ RSpec.describe "Contracts:" do
     end
   end
 
-  describe 'HashOf:' do
-    context 'given a fulfilled contract' do
+  describe "HashOf:" do
+    context "given a fulfilled contract" do
       it { expect(@o.gives_max_value(:panda => 1, :bamboo => 2)).to eq(2) }
     end
 
-    context 'given an unfulfilled contract' do
-      it { expect { @o.gives_max_value(:panda => '1', :bamboo => '2') }.to raise_error(ContractError) }
+    context "given an unfulfilled contract" do
+      it { expect { @o.gives_max_value(:panda => "1", :bamboo => "2") }.to raise_error(ContractError) }
     end
 
-    describe '#to_s' do
-      context 'given Symbol => String' do
-        it { expect(Contracts::HashOf[Symbol, String].to_s).to eq('Hash<Symbol, String>') }
+    describe "#to_s" do
+      context "given Symbol => String" do
+        it { expect(Contracts::HashOf[Symbol, String].to_s).to eq("Hash<Symbol, String>") }
       end
 
-      context 'given String => Num' do
-        it { expect(Contracts::HashOf[String, Contracts::Num].to_s).to eq('Hash<String, Contracts::Num>') }
+      context "given String => Num" do
+        it { expect(Contracts::HashOf[String, Contracts::Num].to_s).to eq("Hash<String, Contracts::Num>") }
       end
     end
   end

--- a/spec/contracts_spec.rb
+++ b/spec/contracts_spec.rb
@@ -341,9 +341,9 @@ RSpec.describe "Contracts:" do
 
   describe "blocks" do
     it "should pass for correct input" do
-      expect do @o.do_call do
+      expect { @o.do_call {
         2 + 2
-      endend.to_not raise_error
+      }}.to_not raise_error
     end
 
     it "should fail for incorrect input" do

--- a/spec/contracts_spec.rb
+++ b/spec/contracts_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe "Contracts:" do
 
     it "should work as expected when there is no contract violation" do
       expect(
-        subject.process_request(PatternMatchingExample::Success[string_with_hello])
-      ).to eq(PatternMatchingExample::Success[expected_decorated_string])
+        subject.process_request(PatternMatchingExample::Success.new(string_with_hello))
+      ).to eq(PatternMatchingExample::Success.new(expected_decorated_string))
 
       expect(
         subject.process_request(PatternMatchingExample::Failure.new)
@@ -34,7 +34,7 @@ RSpec.describe "Contracts:" do
     it "should not fall through to next pattern when there is a deep contract violation" do
       expect(PatternMatchingExample::Failure).not_to receive(:is_a?)
       expect do
-        subject.process_request(PatternMatchingExample::Success[string_without_hello])
+        subject.process_request(PatternMatchingExample::Success.new(string_without_hello))
       end.to raise_error(ContractError)
     end
 
@@ -63,8 +63,8 @@ RSpec.describe "Contracts:" do
 
       it "calls a method when first pattern matches" do
         expect(
-          subject.process_request(PatternMatchingExample::Success[string_with_hello])
-        ).to eq(PatternMatchingExample::Success[expected_decorated_string])
+          subject.process_request(PatternMatchingExample::Success.new(string_with_hello))
+        ).to eq(PatternMatchingExample::Success.new(expected_decorated_string))
       end
 
       it "falls through to 2nd pattern when first pattern does not match" do
@@ -323,19 +323,19 @@ RSpec.describe "Contracts:" do
 
   describe "Hashes" do
     it "should pass for exact correct input" do
-      expect { @o.person({:name => "calvin", :age => 10}) }.to_not raise_error
+      expect { @o.person(:name => "calvin", :age => 10) }.to_not raise_error
     end
 
     it "should pass even if some keys don't have contracts" do
-      expect { @o.person({:name => "calvin", :age => 10, :foo => "bar"}) }.to_not raise_error
+      expect { @o.person(:name => "calvin", :age => 10, :foo => "bar") }.to_not raise_error
     end
 
     it "should fail if a key with a contract on it isn't provided" do
-      expect { @o.person({:name => "calvin"}) }.to raise_error(ContractError)
+      expect { @o.person(:name => "calvin") }.to raise_error(ContractError)
     end
 
     it "should fail for incorrect input" do
-      expect { @o.person({:name => 50, :age => 10}) }.to raise_error(ContractError)
+      expect { @o.person(:name => 50, :age => 10) }.to raise_error(ContractError)
     end
   end
 

--- a/spec/contracts_spec.rb
+++ b/spec/contracts_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe "Contracts:" do
 
   describe "basic" do
     it "should fail for insufficient arguments" do
-      expect {
+      expect do
         @o.hello
-      }.to raise_error
+      end.to raise_error
     end
 
     it "should fail for insufficient contracts" do
@@ -33,15 +33,15 @@ RSpec.describe "Contracts:" do
 
     it "should not fall through to next pattern when there is a deep contract violation" do
       expect(PatternMatchingExample::Failure).not_to receive(:is_a?)
-      expect {
+      expect do
         subject.process_request(PatternMatchingExample::Success[string_without_hello])
-      }.to raise_error(ContractError)
+      end.to raise_error(ContractError)
     end
 
     it "should fail when the pattern-matched method's contract fails" do
-      expect {
+      expect do
         subject.process_request("bad input")
-      }.to raise_error(ContractError)
+      end.to raise_error(ContractError)
     end
 
     it "should work for differing arities" do
@@ -74,9 +74,9 @@ RSpec.describe "Contracts:" do
       end
 
       it "uses overriden failure_callback when pattern matching fails" do
-        expect {
+        expect do
           subject.process_request("hello")
-        }.to raise_error(RuntimeError, /contract violation/)
+        end.to raise_error(RuntimeError, /contract violation/)
       end
     end
   end
@@ -87,13 +87,13 @@ RSpec.describe "Contracts:" do
     end
 
     it "should fail with proper error when there is contract violation" do
-      expect {
+      expect do
         SingletonClassExample.hoge(3)
-      }.to raise_error(ContractError, /Expected: String/)
+      end.to raise_error(ContractError, /Expected: String/)
     end
 
     context "when owner class does not include Contracts" do
-      let(:error) {
+      let(:error) do
         # NOTE Unable to support this user-friendly error for ruby
         # 1.8.7 and jruby 1.8, 1.9 it has much less support for
         # singleton inheritance hierarchy
@@ -102,10 +102,10 @@ RSpec.describe "Contracts:" do
         else
           [NoMethodError, /undefined method `Contract'/]
         end
-      }
+      end
 
       it "fails with descriptive error" do
-        expect {
+        expect do
           Class.new(GenericExample) do
             class << self
               Contract String => String
@@ -114,15 +114,15 @@ RSpec.describe "Contracts:" do
               end
             end
           end
-        }.to raise_error(*error)
+        end.to raise_error(*error)
       end
     end
 
     describe "builtin contracts usage" do
       it "allows to use builtin contracts without namespacing and redundant Contracts inclusion" do
-        expect {
+        expect do
           SingletonClassExample.add("55", 5.6)
-        }.to raise_error(ContractError, /Expected: Num/)
+        end.to raise_error(ContractError, /Expected: Num/)
       end
     end
   end
@@ -246,20 +246,20 @@ RSpec.describe "Contracts:" do
     it "should allow two classes to have the same method with different contracts" do
       a = A.new
       b = B.new
-      expect {
+      expect do
         a.triple(5)
         b.triple("a string")
-      }.to_not raise_error
+      end.to_not raise_error
     end
   end
 
   describe "instance and class methods" do
     it "should allow a class to have an instance method and a class method with the same name" do
       a = A.new
-      expect {
+      expect do
         a.instance_and_class_method(5)
         A.instance_and_class_method("a string")
-      }.to_not raise_error
+      end.to_not raise_error
     end
   end
 
@@ -341,9 +341,9 @@ RSpec.describe "Contracts:" do
 
   describe "blocks" do
     it "should pass for correct input" do
-      expect { @o.do_call {
+      expect do @o.do_call do
         2 + 2
-      }}.to_not raise_error
+      endend.to_not raise_error
     end
 
     it "should fail for incorrect input" do
@@ -376,28 +376,28 @@ RSpec.describe "Contracts:" do
     end
 
     it "should fail for incorrect input" do
-      expect {
+      expect do
         @o.with_partial_sums(1, 2, "bad") { |partial_sum| 2 * partial_sum + 1 }
-      }.to raise_error(ContractError, /Actual: "bad"/)
+      end.to raise_error(ContractError, /Actual: "bad"/)
 
-      expect {
+      expect do
         @o.with_partial_sums(1, 2, 3)
-      }.to raise_error(ContractError, /Actual: nil/)
+      end.to raise_error(ContractError, /Actual: nil/)
 
-      expect {
+      expect do
         @o.with_partial_sums(1, 2, 3, lambda { |x| x })
-      }.to raise_error(ContractError, /Actual: nil/)
+      end.to raise_error(ContractError, /Actual: nil/)
     end
 
     context "when block has Func contract" do
       it "should fail for incorrect input" do
-        expect {
+        expect do
           @o.with_partial_sums_contracted(1, 2, "bad") { |partial_sum| 2 * partial_sum + 1 }
-        }.to raise_error(ContractError, /Actual: "bad"/)
+        end.to raise_error(ContractError, /Actual: "bad"/)
 
-        expect {
+        expect do
           @o.with_partial_sums_contracted(1, 2, 3)
-        }.to raise_error(ContractError, /Actual: nil/)
+        end.to raise_error(ContractError, /Actual: nil/)
       end
     end
   end
@@ -412,7 +412,7 @@ RSpec.describe "Contracts:" do
     end
 
     it "should fail for a function that doesn't pass the contract" do
-      expect { @o.map([1, 2, 3], lambda { |x| "bad return value" }) }.to raise_error(ContractError)
+      expect { @o.map([1, 2, 3], lambda { |_x| "bad return value" }) }.to raise_error(ContractError)
     end
 
     it "should pass for a function that passes the contract with weak other args" do
@@ -420,7 +420,7 @@ RSpec.describe "Contracts:" do
     end
 
     it "should fail for a function that doesn't pass the contract with weak other args" do
-      expect { @o.map_plain(['hello', 'joe'], lambda { |x| nil }) }.to raise_error(ContractError)
+      expect { @o.map_plain(['hello', 'joe'], lambda { |_x| nil }) }.to raise_error(ContractError)
     end
   end
 
@@ -479,57 +479,57 @@ RSpec.describe "Contracts:" do
     end
 
     it "should not stringify native types" do
-      expect {
+      expect do
         @o.constanty('bad', nil)
-      }.to raise_error(ContractError, not_s(123))
+      end.to raise_error(ContractError, not_s(123))
 
-      expect {
+      expect do
         @o.constanty(123, 'bad')
-      }.to raise_error(ContractError, not_s(nil))
+      end.to raise_error(ContractError, not_s(nil))
     end
 
     it "should contain to_s representation within a Hash contract" do
-      expect {
+      expect do
         @o.hash_complex_contracts({ :rigged => 'bad' })
-      }.to raise_error(ContractError, not_s(delim 'TrueClass or FalseClass'))
+      end.to raise_error(ContractError, not_s(delim 'TrueClass or FalseClass'))
     end
 
     it "should contain to_s representation within a nested Hash contract" do
-      expect {
+      expect do
         @o.nested_hash_complex_contracts({ :rigged => true,
                                            :contents => {
                                              :kind => 0, :total => 42 } })
-      }.to raise_error(ContractError, not_s(delim 'String or Symbol'))
+      end.to raise_error(ContractError, not_s(delim 'String or Symbol'))
     end
 
     it "should contain to_s representation within an Array contract" do
-      expect {
+      expect do
         @o.array_complex_contracts(['bad'])
-      }.to raise_error(ContractError, not_s(delim 'TrueClass or FalseClass'))
+      end.to raise_error(ContractError, not_s(delim 'TrueClass or FalseClass'))
     end
 
     it "should contain to_s representation within a nested Array contract" do
-      expect {
+      expect do
         @o.nested_array_complex_contracts([true, [0]])
-      }.to raise_error(ContractError, not_s(delim 'String or Symbol'))
+      end.to raise_error(ContractError, not_s(delim 'String or Symbol'))
     end
 
     it "should not contain Contracts:: module prefix" do
-      expect {
+      expect do
         @o.double('bad')
-      }.to raise_error(ContractError, /Expected: Num/)
+      end.to raise_error(ContractError, /Expected: Num/)
     end
 
     it "should still show nils, not just blank space" do
-      expect {
+      expect do
         @o.no_args('bad')
-      }.to raise_error(ContractError, /Expected: nil/)
+      end.to raise_error(ContractError, /Expected: nil/)
     end
 
     it 'should show empty quotes as ""' do
-      expect {
+      expect do
         @o.no_args("")
-      }.to raise_error(ContractError, /Actual: ""/)
+      end.to raise_error(ContractError, /Actual: ""/)
     end
   end
 

--- a/spec/fixtures/fixtures.rb
+++ b/spec/fixtures/fixtures.rb
@@ -337,7 +337,15 @@ end
 class PatternMatchingExample
   include Contracts
 
-  class Success < Struct.new(:request)
+  class Success
+    attr_accessor :request
+    def initialize request
+      @request = request
+    end
+
+    def ==(other)
+      request = other.request
+    end
   end
 
   class Failure
@@ -347,13 +355,13 @@ class PatternMatchingExample
 
   class StringWithHello
     def self.valid?(string)
-      String === string && !!string.match(/hello/i)
+      string.is_a?(String) && !!string.match(/hello/i)
     end
   end
 
   Contract Success => Response
   def process_request(status)
-    Success[decorated_request(status.request)]
+    Success.new(decorated_request(status.request))
   end
 
   Contract Failure => Response
@@ -382,8 +390,8 @@ class MyBirthday
   include Contracts
   include Contracts::Invariants
 
-  Invariant(:day) { 1 <= day && day <= 31 }
-  Invariant(:month) { 1 <= month && month <= 12 }
+  invariant(:day) { 1 <= day && day <= 31 }
+  invariant(:month) { 1 <= month && month <= 12 }
 
   attr_accessor :day, :month
   def initialize(day, month)
@@ -456,7 +464,7 @@ with_enabled_no_contracts do
 
     attr_accessor :day
 
-    Invariant(:day_rule) { 1 <= day && day <= 7 }
+    invariant(:day_rule) { 1 <= day && day <= 7 }
 
     Contract None => nil
     def next_day

--- a/spec/fixtures/fixtures.rb
+++ b/spec/fixtures/fixtures.rb
@@ -378,12 +378,18 @@ class PatternMatchingExample
 end
 
 # invariant example (silliest implementation ever)
-class MyBirthday < Struct.new(:day, :month)
+class MyBirthday
   include Contracts
   include Contracts::Invariants
 
   Invariant(:day) { 1 <= day && day <= 31 }
   Invariant(:month) { 1 <= month && month <= 12 }
+
+  attr_accessor :day, :month
+  def initialize(day, month)
+    @day = day
+    @month = month
+  end
 
   Contract None => Fixnum
   def silly_next_day!

--- a/spec/fixtures/fixtures.rb
+++ b/spec/fixtures/fixtures.rb
@@ -45,6 +45,7 @@ class C
   def good
     false
   end
+
   def bad
     true
   end
@@ -54,7 +55,7 @@ class GenericExample
   include Contracts
 
   Contract Num => Num
-  def GenericExample.a_class_method x
+  def self.a_class_method x
     x + 1
   end
 
@@ -145,7 +146,7 @@ class GenericExample
   # Important to use different arg types or it falsely passes
   Contract Num, Args[String] => ArrayOf[String]
   def arg_then_splat(n, *vals)
-    vals.map{ |v| v * n }
+    vals.map { |v| v * n }
   end
 
   Contract Num, Proc => nil

--- a/spec/fixtures/fixtures.rb
+++ b/spec/fixtures/fixtures.rb
@@ -344,7 +344,7 @@ class PatternMatchingExample
     end
 
     def ==(other)
-      request = other.request
+      request == other.request
     end
   end
 

--- a/spec/invariants_spec.rb
+++ b/spec/invariants_spec.rb
@@ -1,6 +1,5 @@
 module Contracts
   RSpec.describe Invariants do
-
     def new_subject
       MyBirthday.new(31, 12)
     end
@@ -14,6 +13,5 @@ module Contracts
       expect { new_subject.silly_next_day! }.to raise_error(InvariantError, /day condition to be true/)
       expect { new_subject.silly_next_month! }.to raise_error(InvariantError, /month condition to be true/)
     end
-
   end
 end

--- a/spec/module_spec.rb
+++ b/spec/module_spec.rb
@@ -3,7 +3,7 @@ module Mod
 
   Contract Num => Num
   def self.a_module_method a
-     a + 1
+    a + 1
   end
 end
 
@@ -15,4 +15,4 @@ RSpec.describe "module methods" do
   it "should fail for incorrect input" do
     expect { Mod.a_module_method("bad") }.to raise_error(ContractError)
   end
-end  
+end

--- a/spec/ruby_version_specific/contracts_spec_1.9.rb
+++ b/spec/ruby_version_specific/contracts_spec_1.9.rb
@@ -12,7 +12,7 @@ RSpec.describe "Contracts:" do
 
   describe "Splat not last (or penultimate to block)" do
     it "should work with arg after splat" do
-      expect { @o.splat_then_arg('hello', 'world', 3) }.to_not raise_error
+      expect { @o.splat_then_arg("hello", "world", 3) }.to_not raise_error
     end
   end
 end

--- a/spec/ruby_version_specific/contracts_spec_1.9.rb
+++ b/spec/ruby_version_specific/contracts_spec_1.9.rb
@@ -1,10 +1,9 @@
 class GenericExample
   Contract Args[String], Num => ArrayOf[String]
   def splat_then_arg(*vals, n)
-    vals.map{ |v| v * n }
+    vals.map { |v| v * n }
   end
 end
-
 
 RSpec.describe "Contracts:" do
   before :all do
@@ -17,6 +16,3 @@ RSpec.describe "Contracts:" do
     end
   end
 end
-
-
-

--- a/spec/ruby_version_specific/contracts_spec_2.0.rb
+++ b/spec/ruby_version_specific/contracts_spec_2.0.rb
@@ -1,5 +1,5 @@
 class GenericExample
-  Contract Args[String], { repeat: Maybe[Num] } => ArrayOf[String }
+  Contract Args[String], { repeat: Maybe[Num] } => ArrayOf[String]
   def splat_then_optional_named(*vals, repeat: 2)
     vals.map { |v| v * repeat }
   end

--- a/spec/ruby_version_specific/contracts_spec_2.0.rb
+++ b/spec/ruby_version_specific/contracts_spec_2.0.rb
@@ -12,14 +12,11 @@ RSpec.describe "Contracts:" do
 
   describe "Optional named arguments" do
     it "should work with optional named argument unfilled after splat" do
-      expect { @o.splat_then_optional_named('hello', 'world') }.to_not raise_error
+      expect { @o.splat_then_optional_named("hello", "world") }.to_not raise_error
     end
 
     it "should work with optional named argument filled after splat" do
-      expect { @o.splat_then_optional_named('hello', 'world', repeat: 3) }.to_not raise_error
+      expect { @o.splat_then_optional_named("hello", "world", repeat: 3) }.to_not raise_error
     end
   end
 end
-
-
-

--- a/spec/ruby_version_specific/contracts_spec_2.0.rb
+++ b/spec/ruby_version_specific/contracts_spec_2.0.rb
@@ -1,10 +1,9 @@
 class GenericExample
- Contract Args[String], { repeat: Maybe[Num] } => ArrayOf[String]
+  Contract Args[String], { repeat: Maybe[Num] } => ArrayOf[String }
   def splat_then_optional_named(*vals, repeat: 2)
-    vals.map{ |v| v * repeat }
+    vals.map { |v| v * repeat }
   end
 end
-
 
 RSpec.describe "Contracts:" do
   before :all do

--- a/spec/ruby_version_specific/contracts_spec_2.1.rb
+++ b/spec/ruby_version_specific/contracts_spec_2.1.rb
@@ -1,11 +1,10 @@
 class GenericExample
-  Contract String, Bool, Args[Symbol], Float, { e:Range, f:Maybe[Num] }, Proc =>
+  Contract String, Bool, Args[Symbol], Float, { e: Range, f: Maybe[Num] }, Proc =>
            [Proc, Hash, Num, Range, Float, ArrayOf[Symbol], Bool, String]
-  def complicated(a, b=true, *c, d, e:, f:2, **g, &h)
+  def complicated(a, b = true, *c, d, e:, f:2, **g, &h)
     h.call [h, g, f, e, d, c, b, a]
   end
 end
-
 
 RSpec.describe "Contracts:" do
   before :all do
@@ -22,15 +21,15 @@ RSpec.describe "Contracts:" do
 
       it "should work with all args filled manually, with extra splat and hash" do
         expect do
-          @o.complicated('a', true, :b, :c, 2.0, e: (1..5), f: 8.3, g: :d) {
-            |x| x
-          }
+          @o.complicated('a', true, :b, :c, 2.0, e: (1..5), f: 8.3, g: :d) do |x|
+            x
+          end
         end.to_not raise_error
       end
 
       it "should fail when the return is invalid" do
         expect do
-          @o.complicated('a', true, :b, 2.0, e: (1..5)) { |x| 'bad' }
+          @o.complicated('a', true, :b, 2.0, e: (1..5)) { |_x| 'bad' }
         end.to raise_error(ContractError)
       end
 

--- a/spec/ruby_version_specific/contracts_spec_2.1.rb
+++ b/spec/ruby_version_specific/contracts_spec_2.1.rb
@@ -15,13 +15,13 @@ RSpec.describe "Contracts:" do
     describe "really complicated method signature" do
       it "should work with default named args used" do
         expect do
-          @o.complicated('a', false, :b, 2.0, e: (1..5)) { |x| x }
+          @o.complicated("a", false, :b, 2.0, e: (1..5)) { |x| x }
         end.to_not raise_error
       end
 
       it "should work with all args filled manually, with extra splat and hash" do
         expect do
-          @o.complicated('a', true, :b, :c, 2.0, e: (1..5), f: 8.3, g: :d) do |x|
+          @o.complicated("a", true, :b, :c, 2.0, e: (1..5), f: 8.3, g: :d) do |x|
             x
           end
         end.to_not raise_error
@@ -29,25 +29,25 @@ RSpec.describe "Contracts:" do
 
       it "should fail when the return is invalid" do
         expect do
-          @o.complicated('a', true, :b, 2.0, e: (1..5)) { |_x| 'bad' }
+          @o.complicated("a", true, :b, 2.0, e: (1..5)) { |_x| "bad" }
         end.to raise_error(ContractError)
       end
 
       it "should fail when args are invalid" do
         expect do
-          @o.complicated('a', 'bad', :b, 2.0, e: (1..5)) { |x| x }
+          @o.complicated("a", "bad", :b, 2.0, e: (1..5)) { |x| x }
         end.to raise_error(ContractError)
       end
 
       it "should fail when splat is invalid" do
         expect do
-          @o.complicated('a', true, 'bad', 2.0, e: (1..5)) { |x| x }
+          @o.complicated("a", true, "bad", 2.0, e: (1..5)) { |x| x }
         end.to raise_error(ContractError)
       end
 
       it "should fail when named argument is invalid" do
         expect do
-          @o.complicated('a', true, :b, 2.0, e: 'bad') { |x| x }
+          @o.complicated("a", true, :b, 2.0, e: "bad") { |x| x }
         end.to raise_error(ContractError)
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,7 +65,7 @@ RSpec.configure do |config|
 
   # This setting enables warnings. It's recommended, but in some cases may
   # be too noisy due to issues in dependencies.
-  #config.warnings = true
+  # config.warnings = true
 
   # Many RSpec users commonly either run the entire suite or an individual
   # file, and it's useful to allow more verbose output when running an

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,7 @@ require File.expand_path(File.join(__FILE__, "../fixtures/fixtures"))
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
-  config.pattern = '*.rb'
+  config.pattern = "*.rb"
 
   # Only load tests who's syntax is valid in the current Ruby
   [1.9, 2.0, 2.1].each do |ver|
@@ -74,7 +74,7 @@ RSpec.configure do |config|
     # Use the documentation formatter for detailed output,
     # unless a formatter has already been configured
     # (e.g. via a command-line flag).
-    config.default_formatter = 'doc'
+    config.default_formatter = "doc"
   end
 
   # Print the 10 slowest examples and example groups at the


### PR DESCRIPTION
Fixes all rubocop warnings (issue #21).

I disabled some cops, you can see which ones and my rationales in `rubocop.yml`. Some big changes in this PR:

1. change function name `Invariant` to `invariant` (cc @waterlink). I can see why this was named to be consistent with the `Contract` decorator. But since this is not a decorator, I think it makes more sense for it to be lowercase (consistent with methods like `attr_accessor`).

2. Adding rubocop to travis-ci. It would be nice to follow a coding standard but I don't always catch every minor issue. TBH I also don't like discussing minor issues like that...it feels like bike-shedding. This way, there is one coding standard and it is enforced automatically.

Another reason for doing this: cleaning up code like I did with this PR, changes the history. If a line looks weird and someone does a git blame, they will be taken to this rubocop commit. Not the original commit that might have explained the code. So ideally I don't want to make separate commits like this for code cleanup...and that won't happen if we have rubocop on ci.

What do you think?