### PR TITLE
Fix useful_to_s? on older Rubies < 2.0

### DIFF
--- a/lib/contracts/builtin_contracts.rb
+++ b/lib/contracts/builtin_contracts.rb
@@ -125,8 +125,8 @@ module Contracts
 
     def to_s
       @vals[0, @vals.size-1].map do |x|
-        InspectWrapper.new(x)
-      end.join(", ") + " or " + InspectWrapper.new(@vals[-1]).to_s
+        InspectWrapper.create(x)
+      end.join(", ") + " or " + InspectWrapper.create(@vals[-1]).to_s
     end
 
     # this can only be tested IF all the sub-contracts have a test_data method
@@ -161,8 +161,8 @@ module Contracts
 
     def to_s
       @vals[0, @vals.size-1].map do |x|
-        InspectWrapper.new(x)
-      end.join(", ") + " xor " + InspectWrapper.new(@vals[-1]).to_s
+        InspectWrapper.create(x)
+      end.join(", ") + " xor " + InspectWrapper.create(@vals[-1]).to_s
     end
 
     def testable?
@@ -195,8 +195,8 @@ module Contracts
 
     def to_s
       @vals[0, @vals.size-1].map do |x|
-        InspectWrapper.new(x)
-      end.join(", ") + " and " + InspectWrapper.new(@vals[-1]).to_s
+        InspectWrapper.create(x)
+      end.join(", ") + " and " + InspectWrapper.create(@vals[-1]).to_s
     end
   end
 

--- a/lib/contracts/formatters.rb
+++ b/lib/contracts/formatters.rb
@@ -85,12 +85,19 @@ module Contracts
 
       def useful_to_s?
         # Useless to_s value or no custom to_s behavious defined
-        @value.to_s != "" &&
-          if @value.class == Class # It's a class contract
-            @value.to_s != @value.name
-          else # It's an instance contract
-            !@value.to_s.match(/#\<\w+:.+\>/)
-          end
+        !empty_to_s? && custom_to_s?
+      end
+
+      def empty_to_s?
+        @value.to_s.empty?
+      end
+
+      def custom_to_s?
+        if @value.class == Class # It's a class contract
+          @value.to_s != @value.name
+        else # It's an instance contract
+          !@value.to_s.match(/#\<\w+:.+\>/)
+        end
       end
     end
   end

--- a/lib/contracts/formatters.rb
+++ b/lib/contracts/formatters.rb
@@ -54,7 +54,7 @@ module Contracts
         return @value.inspect if empty_val?
         return @value.to_s if plain?
         return delim(@value.to_s) if useful_to_s?
-        @value.inspect.gsub(/^Contracts::/, "")
+        raw_inspect
       end
 
       def delim(value)
@@ -98,6 +98,15 @@ module Contracts
         else # It's an instance contract
           !@value.to_s.match(/#\<\w+:.+\>/)
         end
+      end
+
+      # Ruby < 2 makes inspect call to_s so we need a custom inspect
+      def raw_inspect
+        if @value.class == Class # It's a class contract
+          empty_to_s? ? @value.name : @value.inspect
+        else # It's an instance contract
+          empty_to_s? ? @value.class.name : @value.inspect
+        end.gsub(/^Contracts::/, "")
       end
     end
   end

--- a/lib/contracts/formatters.rb
+++ b/lib/contracts/formatters.rb
@@ -85,8 +85,12 @@ module Contracts
 
       def useful_to_s?
         # Useless to_s value or no custom to_s behavious defined
-        # Ruby < 2.0 makes inspect call to_s so this won't work
-        @value.to_s != "" && @value.to_s != @value.inspect
+        @value.to_s != "" &&
+          if @value.class == Class # It's a class contract
+            @value.to_s != @value.name
+          else # It's an instance contract
+            !@value.to_s.match(/#\<\w+:.+\>/)
+          end
       end
     end
   end

--- a/spec/contracts_spec.rb
+++ b/spec/contracts_spec.rb
@@ -554,6 +554,12 @@ RSpec.describe "Contracts:" do
         @o.no_args("")
       end.to raise_error(ContractError, /Actual: ""/)
     end
+
+    it 'should not use custom to_s if empty string' do
+      expect {
+        @o.using_empty_contract('bad')
+      }.to raise_error(ContractError, /Expected: EmptyCont/)
+    end
   end
 
   describe "functype" do

--- a/spec/contracts_spec.rb
+++ b/spec/contracts_spec.rb
@@ -555,10 +555,10 @@ RSpec.describe "Contracts:" do
       end.to raise_error(ContractError, /Actual: ""/)
     end
 
-    it 'should not use custom to_s if empty string' do
-      expect {
-        @o.using_empty_contract('bad')
-      }.to raise_error(ContractError, /Expected: EmptyCont/)
+    it "should not use custom to_s if empty string" do
+      expect do
+        @o.using_empty_contract("bad")
+      end.to raise_error(ContractError, /Expected: EmptyCont/)
     end
   end
 

--- a/spec/fixtures/fixtures.rb
+++ b/spec/fixtures/fixtures.rb
@@ -51,6 +51,12 @@ class C
   end
 end
 
+class EmptyCont
+  def self.to_s
+    ''
+  end
+end
+
 class GenericExample
   include Contracts
 
@@ -259,6 +265,11 @@ class GenericExample
   Contract HashOf[Symbol, Num] => Num
   def gives_max_value(hash)
     hash.values.max
+  end
+
+  Contract EmptyCont => Any
+  def using_empty_contract(a)
+    a
   end
 
   Contract nil => String

--- a/spec/fixtures/fixtures.rb
+++ b/spec/fixtures/fixtures.rb
@@ -53,7 +53,7 @@ end
 
 class EmptyCont
   def self.to_s
-    ''
+    ""
   end
 end
 


### PR DESCRIPTION
`useful_to_s?` wasn't useful on Ruby < 2.0 as `#inspect` simply called `#to_s` so they were always the same. I've fixed that so it works properly in all Rubies.