### PR TITLE
Receiver contract

### DIFF
--- a/lib/contracts/builtin_contracts.rb
+++ b/lib/contracts/builtin_contracts.rb
@@ -441,4 +441,10 @@ module Contracts
       @contracts = contracts
     end
   end
+
+  class Receiver
+    def self.valid? val, context
+      val.is_a? context[:receiver].class
+    end
+  end
 end

--- a/spec/builtin_contracts_spec.rb
+++ b/spec/builtin_contracts_spec.rb
@@ -259,4 +259,23 @@ RSpec.describe "Contracts:" do
       end
     end
   end
+
+  describe "Receiver:" do
+    subject { subject_class.new 3 }
+    let(:subject_class) { Class.new ReceiverExample }
+    let(:sibling) { Class.new ReceiverExample }
+    let(:child) { Class.new subject_class }
+
+    it "fails on sibling classes" do
+      expect { subject.append sibling.new 2 }.to raise_error ContractError
+    end
+
+    it "passes for instances of the receiver" do
+      expect(subject.append(subject_class.new 2).value).to eq 5
+    end
+
+    it "passes for children of the receiver" do
+      expect(subject.append(child.new 2).value).to eq 5
+    end
+  end
 end

--- a/spec/fixtures/fixtures.rb
+++ b/spec/fixtures/fixtures.rb
@@ -333,6 +333,21 @@ class GenericExample
   end
 end
 
+class ReceiverExample
+  include Contracts
+  attr_accessor :value
+
+  Contract Num => Any
+  def initialize(initial_value)
+    @value = initial_value
+  end
+
+  Contract Receiver => Receiver
+  def append(other)
+    self.class.new(value + other.value)
+  end
+end
+
 # pattern matching example with possible deep contract violation
 class PatternMatchingExample
   include Contracts


### PR DESCRIPTION
This adds a receiver contract which automatically narrows when inherited.

### Example ###

Let's say we've got a class hierarchy that goes something like this:

```ruby
class BaseCounter
  Contract None => Num
  attr_accessor :value

  Contract Num => Any
  def initialize(initial_value)
    @value = initial_value
  end

  Contract BaseCounter => BaseCounter
  def +(other)
    self.class.new(value + other.value)
  end
end

class RedCounter < BaseCounter; end
class BlueCounter < BaseCounter; end
```

With these classes, we could do something like this:

```ruby
red1 = RedCounter.new 3
red2 = RedCounter.new 5

red1 + red2
# => #<RedCounter @value=8>
```

That's pretty nifty, but we run into a problem:

```ruby
red = RedCounter.new 3
blue = BlueCounter.new 5

red + blue
# => #<RedCounter @value=8>
```

When we created the class hierarchy, we didn't want red and blue counters to mix. They've got the same parent class, but that doesn't mean that we wanted them to be interchangeable.

This PR adds a new kind of contract that handles this use case.

```ruby
class BaseCounter
  Contract None => Num
  attr_accessor :value

  Contract Num => Any
  def initialize(initial_value)
    @value = initial_value
  end

  # Note that these are Receiver contracts now, instead of BaseCounter
  Contract Receiver => Receiver
  def +(other)
    self.class.new(value + other.value)
  end
end

class RedCounter < BaseCounter; end
class BlueCounter < BaseCounter; end

red = RedCounter.new 3
blue = BlueCounter.new 5

red + blue
# => Contract violation for argument 1 of 1: (ContractError)
# ~>         Expected: Receiver,
# ~>         Actual: #<BlueCounter @value=5>
# ~>         Value guarded in: BaseCounter::+
# ~>         With Contract: Receiver => Receiver
```

### Notes ###

This contract didn't lend itself particularly well to the way Contracts is structured. I had to add a receiver stack (implemented to be thread and fiber safe), and perform arity checking to see if the receiver data should be passed along.

My biggest complaint about this contract is that it doesn't print out very nicely. Rather than `Expected: Receiver`, it would be nice to see `Expected: RedCounter`. Once again, it would require a fair degree of refactoring the contract inspection code to make that work well, so I'm leaving it alone at the moment.

I'd be happy to add some documentation for this contract, but I wanted to see how people feel about this contract first.