### PR TITLE
Change syntax for no arguments

### DIFF
--- a/lib/contracts/decorators.rb
+++ b/lib/contracts/decorators.rb
@@ -93,14 +93,14 @@ module Contracts
       # Here's why: Suppose you have this code:
       #
       #     class Foo
-      #       Contract nil => String
+      #       Contract String
       #       def to_s
       #         "Foo"
       #       end
       #     end
       #
       #     class Bar < Foo
-      #       Contract nil => String
+      #       Contract String
       #       def to_s
       #         super + "Bar"
       #       end

--- a/spec/fixtures/fixtures.rb
+++ b/spec/fixtures/fixtures.rb
@@ -216,7 +216,7 @@ class GenericExample
   def bool_test(x)
   end
 
-  Contract nil => Num
+  Contract Num
   def no_args
     1
   end
@@ -272,13 +272,13 @@ class GenericExample
     a
   end
 
-  Contract nil => String
+  Contract String
   def a_private_method
     "works"
   end
   private :a_private_method
 
-  Contract nil => String
+  Contract String
   def a_protected_method
     "works"
   end
@@ -286,14 +286,14 @@ class GenericExample
 
   private
 
-  Contract nil => String
+  Contract String
   def a_really_private_method
     "works for sure"
   end
 
   protected
 
-  Contract nil => String
+  Contract String
   def a_really_protected_method
     "works for sure"
   end


### PR DESCRIPTION
In many languages, a type signature for a function that increments a number by one looks like `Num -> Num`, which is represented fine in this library as `Contract Num => Num`. But for a function that just returns a value, say pi: What is pi? Pi is a Num (or Float/BigDecimal/whatever). Pi is not a `nil => Num`. I think it would improve the readability of the contract type signatures if there was a way to express the type of a declared value or computed value as a single type, and omit the `nil =>`.

This change allows you to write:

```rb
Contract Num
def pi
  3.14
end
```