### PR TITLE
Make HashOf contract prettier

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -80,7 +80,7 @@ contracts.ruby comes with a lot of built-in contracts, including the following:
 * [`Not`](http://www.rubydoc.info/gems/contracts/Contracts/Not) – passes if all contracts fail for the given argument, e.g. `Not[nil]`
 * [`ArrayOf`](http://www.rubydoc.info/gems/contracts/Contracts/ArrayOf) – checks that the argument is an array, and all elements pass the given contract, e.g. `ArrayOf[Num]`
 * [`SetOf`](http://www.rubydoc.info/gems/contracts/Contracts/SetOf) – checks that the argument is a set, and all elements pass the given contract, e.g. `SetOf[Num]`
-* [`HashOf`](http://www.rubydoc.info/gems/contracts/Contracts/HashOf) – checks that the argument is a hash, and all keys and values pass the given contract, e.g. `HashOf[Symbol, String]`
+* [`HashOf`](http://www.rubydoc.info/gems/contracts/Contracts/HashOf) – checks that the argument is a hash, and all keys and values pass the given contract, e.g. `HashOf[Symbol => String]`
 * [`Maybe`](http://www.rubydoc.info/gems/contracts/Contracts/Maybe) – passes if the argument is `nil`, or if the given contract passes
 * [`RespondTo`](http://www.rubydoc.info/gems/contracts/Contracts/RespondTo) – checks that the argument responds to all of the given methods, e.g. `RespondTo[:password, :credit_card]`
 * [`Send`](http://www.rubydoc.info/gems/contracts/Contracts/Send) – checks that all named methods return true, e.g. `Send[:valid?]`

--- a/lib/contracts/builtin_contracts.rb
+++ b/lib/contracts/builtin_contracts.rb
@@ -315,9 +315,14 @@ module Contracts
   # one for hash keys and one for hash values.
   # Example: <tt>HashOf[Symbol, String]</tt>
   class HashOf < CallableClass
-    def initialize(key, value)
-      @key   = key
-      @value = value
+    def initialize(key, value = nil)
+      if value
+        @key   = key
+        @value = value
+      else
+        @key   = key.keys.first
+        @value = key[@key]
+      end
     end
 
     def valid?(hash)

--- a/lib/contracts/builtin_contracts.rb
+++ b/lib/contracts/builtin_contracts.rb
@@ -320,6 +320,7 @@ module Contracts
         @key   = key
         @value = value
       else
+        validate_hash(key)
         @key   = key.keys.first
         @value = key[@key]
       end
@@ -334,6 +335,14 @@ module Contracts
 
     def to_s
       "Hash<#{@key}, #{@value}>"
+    end
+
+    private
+
+    def validate_hash(hash)
+      unless hash.count == 1
+        raise ArgumentError, "You should provide only one key-value pair to HashOf contract"
+      end
     end
   end
 

--- a/lib/contracts/builtin_contracts.rb
+++ b/lib/contracts/builtin_contracts.rb
@@ -315,6 +315,8 @@ module Contracts
   # one for hash keys and one for hash values.
   # Example: <tt>HashOf[Symbol, String]</tt>
   class HashOf < CallableClass
+    INVALID_KEY_VALUE_PAIR = "You should provide only one key-value pair to HashOf contract"
+
     def initialize(key, value = nil)
       if value
         @key   = key
@@ -340,9 +342,7 @@ module Contracts
     private
 
     def validate_hash(hash)
-      unless hash.count == 1
-        raise ArgumentError, "You should provide only one key-value pair to HashOf contract"
-      end
+      fail ArgumentError, INVALID_KEY_VALUE_PAIR unless hash.count == 1
     end
   end
 

--- a/spec/builtin_contracts_spec.rb
+++ b/spec/builtin_contracts_spec.rb
@@ -255,6 +255,19 @@ RSpec.describe "Contracts:" do
   end
 
   describe "HashOf:" do
+    it "doesn't allow to specify multiple key-value pairs with pretty syntax" do
+      expect {
+        Class.new do
+          include Contracts
+
+          Contract Contracts::HashOf[Symbol => String, Contracts::Num => Contracts::Num] => nil
+          def something(hash)
+            # ...
+          end
+        end
+      }.to raise_error(ArgumentError, "You should provide only one key-value pair to HashOf contract")
+    end
+
     context "given a fulfilled contract" do
       it { expect(@o.gives_max_value(:panda => 1, :bamboo => 2)).to eq(2) }
       it { expect(@o.pretty_gives_max_value(:panda => 1, :bamboo => 2)).to eq(2) }

--- a/spec/builtin_contracts_spec.rb
+++ b/spec/builtin_contracts_spec.rb
@@ -257,10 +257,12 @@ RSpec.describe "Contracts:" do
   describe "HashOf:" do
     context "given a fulfilled contract" do
       it { expect(@o.gives_max_value(:panda => 1, :bamboo => 2)).to eq(2) }
+      it { expect(@o.pretty_gives_max_value(:panda => 1, :bamboo => 2)).to eq(2) }
     end
 
     context "given an unfulfilled contract" do
       it { expect { @o.gives_max_value(:panda => "1", :bamboo => "2") }.to raise_error(ContractError) }
+      it { expect { @o.pretty_gives_max_value(:panda => "1", :bamboo => "2") }.to raise_error(ContractError) }
     end
 
     describe "#to_s" do

--- a/spec/builtin_contracts_spec.rb
+++ b/spec/builtin_contracts_spec.rb
@@ -256,7 +256,7 @@ RSpec.describe "Contracts:" do
 
   describe "HashOf:" do
     it "doesn't allow to specify multiple key-value pairs with pretty syntax" do
-      expect {
+      expect do
         Class.new do
           include Contracts
 
@@ -265,7 +265,7 @@ RSpec.describe "Contracts:" do
             # ...
           end
         end
-      }.to raise_error(ArgumentError, "You should provide only one key-value pair to HashOf contract")
+      end.to raise_error(ArgumentError, "You should provide only one key-value pair to HashOf contract")
     end
 
     context "given a fulfilled contract" do

--- a/spec/fixtures/fixtures.rb
+++ b/spec/fixtures/fixtures.rb
@@ -274,6 +274,11 @@ class GenericExample
     hash.values.max
   end
 
+  Contract HashOf[Symbol => Num] => Num
+  def pretty_gives_max_value(hash)
+    hash.values.max
+  end
+
   Contract EmptyCont => Any
   def using_empty_contract(a)
     a


### PR DESCRIPTION
Adds ability to use `HashOf` in this manner:

```ruby
Contract HashOf[KeyContract => ValueContract] => ...
```

WDYT?

btw, old syntax is still preserved, ie: `HashOf[KeyContract, ValueContract]`