### PR TITLE
Fix Pos,Neg contracts which fail incorrectly for nil values

### DIFF
--- a/lib/contracts/builtin_contracts.rb
+++ b/lib/contracts/builtin_contracts.rb
@@ -29,14 +29,14 @@ module Contracts
   # Check that an argument is a positive number.
   class Pos
     def self.valid? val
-      val > 0
+      val && val > 0
     end
   end
 
   # Check that an argument is a negative number.
   class Neg
     def self.valid? val
-      val < 0
+      val && val < 0
     end
   end
 

--- a/spec/builtin_contracts_spec.rb
+++ b/spec/builtin_contracts_spec.rb
@@ -29,6 +29,10 @@ RSpec.describe "Contracts:" do
     it "should fail for negative numbers" do
       expect { @o.pos_test(-1) }.to raise_error(ContractError)
     end
+
+    it "should fail for nil" do
+      expect { @o.pos_test(nil) }.to raise_error(ContractError)
+    end
   end
 
   describe "Neg:" do
@@ -42,6 +46,10 @@ RSpec.describe "Contracts:" do
 
     it "should fail for positive numbers" do
       expect { @o.neg_test(1) }.to raise_error(ContractError)
+    end
+
+    it "should fail for nil" do
+      expect { @o.neg_test(nil) }.to raise_error(ContractError)
     end
   end
 
@@ -60,6 +68,10 @@ RSpec.describe "Contracts:" do
 
     it "should fail for negative numbers" do
       expect { @o.nat_test(-1) }.to raise_error(ContractError)
+    end
+
+    it "should fail for nil" do
+      expect { @o.nat_test(nil) }.to raise_error(ContractError)
     end
   end
 


### PR DESCRIPTION
Pos and Neg contracts explode when passed nil values. This is most easily noticed when combined with Maybe -  `Maybe[Pos]` - which will error when a positive value is not provided.

For example:
```
  1) Contracts: Pos: should fail for nil
     Failure/Error: expect { @o.pos_test(nil) }.to raise_error(ContractError)
       expected ContractError, got #<NoMethodError: undefined method `>' for nil:NilClass>
```