### PR TITLE
Add KeywordArgs and Optional contracts

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -264,7 +264,14 @@ But this will not quite work if you want to have a default values:
 ```ruby
 Contract String, { :port => Num, :user => String, :password => String } => Connection
 def connect(host, port: 5000, user:, password:)
+  # ...
+end
+
+# No value is passed for port
+connect("example.org", user: "me", password: "none")
 ```
+
+Results in:
 
 ```
 ContractError: Contract violation for argument 2 of 2:
@@ -276,7 +283,7 @@ ContractError: Contract violation for argument 2 of 2:
 ```
 
 This can be fixed with contract `{ :port => Maybe[Num], ... }`, but that will
-allow `nil` to be passed, which is not the original intent.
+allow `nil` to be passed in, which is not the original intent.
 
 So that is where `OptHash` and `Opt` contracts jump in:
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -81,8 +81,8 @@ contracts.ruby comes with a lot of built-in contracts, including the following:
 * [`ArrayOf`](http://www.rubydoc.info/gems/contracts/Contracts/ArrayOf) – checks that the argument is an array, and all elements pass the given contract, e.g. `ArrayOf[Num]`
 * [`SetOf`](http://www.rubydoc.info/gems/contracts/Contracts/SetOf) – checks that the argument is a set, and all elements pass the given contract, e.g. `SetOf[Num]`
 * [`HashOf`](http://www.rubydoc.info/gems/contracts/Contracts/HashOf) – checks that the argument is a hash, and all keys and values pass the given contract, e.g. `HashOf[Symbol => String]`
-* [`OptHash`](http://www.rubydoc.info/gems/contracts/Contracts/OptHash) – checks that the argument is an options hash, and all required keyword arguments are present, and all values pass their respective contracts, e.g. `OptHash[:number => Num, :description => Opt[String]]`
-* [`Opt`](http://www.rubydoc.info/gems/contracts/Contracts/Opt) – checks that the keyword argument is either not present or pass the given contract, can not be used outside of `OptHash` contract, e.g. `Opt[Num]`
+* [`KeywordArgs`](http://www.rubydoc.info/gems/contracts/Contracts/KeywordArgs) – checks that the argument is an options hash, and all required keyword arguments are present, and all values pass their respective contracts, e.g. `KeywordArgs[:number => Num, :description => Optional[String]]`
+* [`Optional`](http://www.rubydoc.info/gems/contracts/Contracts/Optional) – checks that the keyword argument is either not present or pass the given contract, can not be used outside of `KeywordArgs` contract, e.g. `Optional[Num]`
 * [`Maybe`](http://www.rubydoc.info/gems/contracts/Contracts/Maybe) – passes if the argument is `nil`, or if the given contract passes
 * [`RespondTo`](http://www.rubydoc.info/gems/contracts/Contracts/RespondTo) – checks that the argument responds to all of the given methods, e.g. `RespondTo[:password, :credit_card]`
 * [`Send`](http://www.rubydoc.info/gems/contracts/Contracts/Send) – checks that all named methods return true, e.g. `Send[:valid?]`
@@ -285,14 +285,14 @@ ContractError: Contract violation for argument 2 of 2:
 This can be fixed with contract `{ :port => Maybe[Num], ... }`, but that will
 allow `nil` to be passed in, which is not the original intent.
 
-So that is where `OptHash` and `Opt` contracts jump in:
+So that is where `KeywordArgs` and `Optional` contracts jump in:
 
 ```ruby
-Contract String, OptHash[ :port => Opt[Num], :user => String, :password => String ] => Connection
+Contract String, KeywordArgs[ :port => Optional[Num], :user => String, :password => String ] => Connection
 def connect(host, port: 5000, user:, password:)
 ```
 
-It looks just like the hash contract, but wrapped in `OptHash` contract. Notice the usage of `Opt` contract - this way you specify that `:port` argument is optional. And it will not fail, when you omit this argument, but it will fail when you pass in `nil`.
+It looks just like the hash contract, but wrapped in `KeywordArgs` contract. Notice the usage of `Optional` contract - this way you specify that `:port` argument is optional. And it will not fail, when you omit this argument, but it will fail when you pass in `nil`.
 
 ### Contracts On Functions
 

--- a/lib/contracts/builtin_contracts.rb
+++ b/lib/contracts/builtin_contracts.rb
@@ -346,20 +346,20 @@ module Contracts
   end
 
   # Use this for specifying contracts for keyword arguments
-  # Example: <tt>OptHash[ e: Range, f: Opt[Num] ]</tt>
-  class OptHash < CallableClass
+  # Example: <tt>KeywordArgs[ e: Range, f: Optional[Num] ]</tt>
+  class KeywordArgs < CallableClass
     def initialize(options)
       @options = options
     end
 
     def valid?(hash)
       options.all? do |key, contract|
-        Opt._valid?(hash, key, contract)
+        Optional._valid?(hash, key, contract)
       end
     end
 
     def to_s
-      "OptHash[#{options}]"
+      "KeywordArgs[#{options}]"
     end
 
     def inspect
@@ -372,13 +372,13 @@ module Contracts
   end
 
   # Use this for specifying optional keyword argument
-  # Example: <tt>Opt[Num]</tt>
-  class Opt < CallableClass
+  # Example: <tt>Optional[Num]</tt>
+  class Optional < CallableClass
     UNABLE_TO_USE_OUTSIDE_OF_OPT_HASH =
-      "Unable to use Opt contract outside of OptHash contract"
+      "Unable to use Optional contract outside of KeywordArgs contract"
 
     def self._valid?(hash, key, contract)
-      return Contract.valid?(hash[key], contract) unless contract.is_a?(Opt)
+      return Contract.valid?(hash[key], contract) unless contract.is_a?(Optional)
       contract.within_opt_hash!
       !hash.key?(key) || Contract.valid?(hash[key], contract)
     end
@@ -399,7 +399,7 @@ module Contracts
     end
 
     def to_s
-      "Opt[#{formatted_contract}]"
+      "Optional[#{formatted_contract}]"
     end
 
     def inspect

--- a/lib/contracts/builtin_contracts.rb
+++ b/lib/contracts/builtin_contracts.rb
@@ -359,7 +359,7 @@ module Contracts
     end
 
     def to_s
-      "OptHash[#{options}]".gsub(/Contracts::/, "")
+      "OptHash[#{options}]"
     end
 
     def inspect
@@ -399,7 +399,7 @@ module Contracts
     end
 
     def to_s
-      "Opt[#{contract}]"
+      "Opt[#{formatted_contract}]"
     end
 
     def inspect
@@ -413,6 +413,10 @@ module Contracts
     def ensure_within_opt_hash
       return if within_opt_hash
       fail ArgumentError, UNABLE_TO_USE_OUTSIDE_OF_OPT_HASH
+    end
+
+    def formatted_contract
+      Formatters::InspectWrapper.create(contract)
     end
   end
 

--- a/spec/builtin_contracts_spec.rb
+++ b/spec/builtin_contracts_spec.rb
@@ -266,6 +266,14 @@ RSpec.describe "Contracts:" do
     end
   end
 
+  describe "Opt:" do
+    it "can't be used outside of OptHash" do
+      expect do
+        BareOptContractUsed.new.something(3, 5)
+      end.to raise_error(ArgumentError, Contracts::Opt::UNABLE_TO_USE_OUTSIDE_OF_OPT_HASH)
+    end
+  end
+
   describe "HashOf:" do
     it "doesn't allow to specify multiple key-value pairs with pretty syntax" do
       expect do

--- a/spec/builtin_contracts_spec.rb
+++ b/spec/builtin_contracts_spec.rb
@@ -266,11 +266,11 @@ RSpec.describe "Contracts:" do
     end
   end
 
-  describe "Opt:" do
-    it "can't be used outside of OptHash" do
+  describe "Optional:" do
+    it "can't be used outside of KeywordArgs" do
       expect do
-        BareOptContractUsed.new.something(3, 5)
-      end.to raise_error(ArgumentError, Contracts::Opt::UNABLE_TO_USE_OUTSIDE_OF_OPT_HASH)
+        BareOptionalContractUsed.new.something(3, 5)
+      end.to raise_error(ArgumentError, Contracts::Optional::UNABLE_TO_USE_OUTSIDE_OF_OPT_HASH)
     end
   end
 

--- a/spec/fixtures/fixtures.rb
+++ b/spec/fixtures/fixtures.rb
@@ -579,3 +579,12 @@ end
 
 class SingletonInheritanceExampleSubclass < SingletonInheritanceExample
 end
+
+class BareOptContractUsed
+  include Contracts
+
+  Contract Num, Opt[Num] => nil
+  def something(a, b)
+    nil
+  end
+end

--- a/spec/fixtures/fixtures.rb
+++ b/spec/fixtures/fixtures.rb
@@ -580,10 +580,10 @@ end
 class SingletonInheritanceExampleSubclass < SingletonInheritanceExample
 end
 
-class BareOptContractUsed
+class BareOptionalContractUsed
   include Contracts
 
-  Contract Num, Opt[Num] => nil
+  Contract Num, Optional[Num] => nil
   def something(a, b)
     nil
   end

--- a/spec/ruby_version_specific/contracts_spec_2.1.rb
+++ b/spec/ruby_version_specific/contracts_spec_2.1.rb
@@ -1,6 +1,6 @@
 class GenericExample
-  Contract String, Bool, Args[Symbol], Float, { e: Range, f: Maybe[Num] }, Proc =>
-           [Proc, Hash, Num, Range, Float, ArrayOf[Symbol], Bool, String]
+  Contract String, Bool, Args[Symbol], Float, OptHash[e: Range, f: Opt[Num]], Proc =>
+           [Proc, Hash, Maybe[Num], Range, Float, ArrayOf[Symbol], Bool, String]
   def complicated(a, b = true, *c, d, e:, f:2, **g, &h)
     h.call [h, g, f, e, d, c, b, a]
   end
@@ -49,6 +49,14 @@ RSpec.describe "Contracts:" do
         expect do
           @o.complicated("a", true, :b, 2.0, e: "bad") { |x| x }
         end.to raise_error(ContractError)
+      end
+
+      it "should fail when passed nil to an optional argument which contract shouldnt accept nil" do
+        expect do
+          @o.complicated("a", true, :b, :c, 2.0, e: (1..5), f: nil, g: :d) do |x|
+            x
+          end
+        end.to raise_error(ContractError, /Expected: \(OptHash\[{:e=>Range, :f=>Opt\[Num\]}\]\)/)
       end
     end
   end

--- a/spec/ruby_version_specific/contracts_spec_2.1.rb
+++ b/spec/ruby_version_specific/contracts_spec_2.1.rb
@@ -1,5 +1,5 @@
 class GenericExample
-  Contract String, Bool, Args[Symbol], Float, OptHash[e: Range, f: Opt[Num]], Proc =>
+  Contract String, Bool, Args[Symbol], Float, KeywordArgs[e: Range, f: Optional[Num]], Proc =>
            [Proc, Hash, Maybe[Num], Range, Float, ArrayOf[Symbol], Bool, String]
   def complicated(a, b = true, *c, d, e:, f:2, **g, &h)
     h.call [h, g, f, e, d, c, b, a]
@@ -56,7 +56,7 @@ RSpec.describe "Contracts:" do
           @o.complicated("a", true, :b, :c, 2.0, e: (1..5), f: nil, g: :d) do |x|
             x
           end
-        end.to raise_error(ContractError, /Expected: \(OptHash\[{:e=>Range, :f=>Opt\[Num\]}\]\)/)
+        end.to raise_error(ContractError, /Expected: \(KeywordArgs\[{:e=>Range, :f=>Optional\[Num\]}\]\)/)
       end
     end
   end


### PR DESCRIPTION
Fixes #131 

Allows to do this:

```ruby
Contract OptHash[nfiles: Opt[Nat], mfiles: Nat] => ArrayOf[String]
def list(nfiles: 10, mfiles:)
  []
end

# both of these work as expected
list(nfiles: 4, mfiles: 77)
list(mfiles: 77)

# and this will fail with contract error as expected as opposed to `Maybe[Nat]` solution
list(mfiles: 77, nfiles: nil)
```

Contract names are subject to discussion.