### PR TITLE
Rename "Support" module to "ContractsSupport"

### DIFF
--- a/benchmarks/bench.rb
+++ b/benchmarks/bench.rb
@@ -44,7 +44,7 @@ def profile
   profilers << MethodProfiler.observe(Object)
   profilers << MethodProfiler.observe(Contracts::MethodDecorators)
   profilers << MethodProfiler.observe(Contracts::Decorator)
-  profilers << MethodProfiler.observe(Contracts::Support)
+  profilers << MethodProfiler.observe(Contracts::ContractsSupport)
   profilers << MethodProfiler.observe(UnboundMethod)
   10_000.times do |_|
     contracts_add(rand(1000), rand(1000))

--- a/benchmarks/invariants.rb
+++ b/benchmarks/invariants.rb
@@ -60,7 +60,7 @@ def profile
   profilers = []
   profilers << MethodProfiler.observe(Contract)
   profilers << MethodProfiler.observe(Object)
-  profilers << MethodProfiler.observe(Contracts::Support)
+  profilers << MethodProfiler.observe(Contracts::ContractsSupport)
   profilers << MethodProfiler.observe(Contracts::Invariants)
   profilers << MethodProfiler.observe(Contracts::Invariants::InvariantExtension)
   profilers << MethodProfiler.observe(UnboundMethod)

--- a/benchmarks/io.rb
+++ b/benchmarks/io.rb
@@ -39,7 +39,7 @@ def profile
   profilers << MethodProfiler.observe(Object)
   profilers << MethodProfiler.observe(Contracts::MethodDecorators)
   profilers << MethodProfiler.observe(Contracts::Decorator)
-  profilers << MethodProfiler.observe(Contracts::Support)
+  profilers << MethodProfiler.observe(Contracts::ContractsSupport)
   profilers << MethodProfiler.observe(UnboundMethod)
   10.times do |_|
     contracts_download(@urls.sample)

--- a/lib/contracts.rb
+++ b/lib/contracts.rb
@@ -4,7 +4,7 @@ require "contracts/errors"
 require "contracts/formatters"
 require "contracts/invariants"
 require "contracts/method_reference"
-require "contracts/support"
+require "contracts/contracts_support"
 require "contracts/engine"
 require "contracts/method_handler"
 
@@ -136,8 +136,8 @@ class Contract < Contracts::Decorator
   # and uses the hash passed into the failure_callback method.
   def self.failure_msg(data)
     expected = Contracts::Formatters::Expected.new(data[:contract]).contract
-    position = Contracts::Support.method_position(data[:method])
-    method_name = Contracts::Support.method_name(data[:method])
+    position = Contracts::ContractsSupport.method_position(data[:method])
+    method_name = Contracts::ContractsSupport.method_name(data[:method])
 
     header = if data[:return_value]
                "Contract violation for return value:"

--- a/lib/contracts/contracts_support.rb
+++ b/lib/contracts/contracts_support.rb
@@ -1,5 +1,5 @@
 module Contracts
-  module Support
+  module ContractsSupport
     class << self
       def method_position(method)
         return method.method_position if method.is_a?(MethodReference)

--- a/lib/contracts/engine/base.rb
+++ b/lib/contracts/engine/base.rb
@@ -117,7 +117,7 @@ module Contracts
       end
 
       def eigenclass
-        Support.eigenclass_of(klass)
+        ContractsSupport.eigenclass_of(klass)
       end
 
       def eigenclass_engine

--- a/lib/contracts/engine/target.rb
+++ b/lib/contracts/engine/target.rb
@@ -57,11 +57,11 @@ module Contracts
       end
 
       def eigenclass
-        Support.eigenclass_of(target)
+        ContractsSupport.eigenclass_of(target)
       end
 
       def meaningless_eigenclass?
-        !Support.eigenclass?(target)
+        !ContractsSupport.eigenclass?(target)
       end
     end
   end

--- a/lib/contracts/invariants.rb
+++ b/lib/contracts/invariants.rb
@@ -60,8 +60,8 @@ module Contracts
         %{Invariant violation:
             Expected: #{data[:expected]}
             Actual: #{data[:actual]}
-            Value guarded in: #{data[:target].class}::#{Support.method_name(data[:method])}
-            At: #{Support.method_position(data[:method])}}
+            Value guarded in: #{data[:target].class}::#{ContractsSupport.method_name(data[:method])}
+            At: #{ContractsSupport.method_position(data[:method])}}
       end
     end
   end

--- a/lib/contracts/method_reference.rb
+++ b/lib/contracts/method_reference.rb
@@ -13,7 +13,7 @@ module Contracts
 
     # Returns method_position, delegates to Support.method_position
     def method_position
-      Support.method_position(@method)
+      ContractsSupport.method_position(@method)
     end
 
     # Makes a method re-definition in proper way
@@ -76,7 +76,7 @@ module Contracts
     end
 
     def construct_unique_name
-      :"__contracts_ruby_original_#{name}_#{Support.unique_id}"
+      :"__contracts_ruby_original_#{name}_#{ContractsSupport.unique_id}"
     end
   end
 
@@ -94,7 +94,7 @@ module Contracts
 
     # Return alias target for singleton methods.
     def alias_target(this)
-      Support.eigenclass_of this
+      ContractsSupport.eigenclass_of this
     end
   end
 end

--- a/spec/contracts_spec.rb
+++ b/spec/contracts_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe "Contracts:" do
         # NOTE Unable to support this user-friendly error for ruby
         # 1.8.7 and jruby 1.8, 1.9 it has much less support for
         # singleton inheritance hierarchy
-        if Contracts::Support.eigenclass_hierarchy_supported?
+        if Contracts::ContractsSupport.eigenclass_hierarchy_supported?
           [Contracts::ContractsNotIncluded, Contracts::ContractsNotIncluded::DEFAULT_MESSAGE]
         else
           [NoMethodError, /undefined method `Contract'/]

--- a/spec/support_spec.rb
+++ b/spec/support_spec.rb
@@ -1,20 +1,20 @@
 module Contracts
-  RSpec.describe Support do
+  RSpec.describe ContractsSupport do
     describe "eigenclass?" do
       it "is falsey for non-singleton classes" do
-        expect(Contracts::Support.eigenclass? String).to be_falsey
+        expect(Contracts::ContractsSupport.eigenclass? String).to be_falsey
       end
 
       it "is truthy for singleton classes" do
         singleton_class = String.instance_exec { class << self; self; end }
-        expect(Contracts::Support.eigenclass? singleton_class).to be_truthy
+        expect(Contracts::ContractsSupport.eigenclass? singleton_class).to be_truthy
       end
     end
 
     describe "eigenclass_of" do
       it "returns the eigenclass of a given object" do
         singleton_class = String.instance_exec { class << self; self; end }
-        expect(Contracts::Support.eigenclass_of String).to eq singleton_class
+        expect(Contracts::ContractsSupport.eigenclass_of String).to eq singleton_class
       end
     end
   end


### PR DESCRIPTION
Hi,

I'm beginning to use your great gem with one of my (rails) project but I have a namespace collision with your "Support" module.

Is it possible to rename it to "ContractsSupport" as proposed in this PR ?


KR,
Jules