### PR TITLE
Refactor validator strategies + Add ability to override validators

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -509,6 +509,36 @@ end
 
 If your failure callback returns `false`, the method that the contract is guarding will not be called (the default behaviour).
 
+## Providing your own custom validators
+
+This can be done with `Contract.override_validator`:
+
+```ruby
+# Make contracts accept all RSpec doubles
+Contract.override_validator(:class) do |contract|
+  lambda do |arg|
+    arg.is_a?(RSpec::Mocks::Double) ||
+      arg.is_a?(contract)
+  end
+end
+```
+
+The block you provide should always return lambda accepting one argument - validated argument. Block itself accepts contract as an argument.
+
+Possible validator overrides:
+
+- `override_validator(MyCustomContract)` - allows to add some special behaviour for custom contracts,
+- `override_validator(Proc)` - e.g. `lambda { true }`,
+- `override_validator(Array)` - e.g. `[Num, String]`,
+- `override_validator(Hash)` - e.g. `{ :a => Num, :b => String }`,
+- `override_validator(Contracts::Args)` - e.g. `Args[Num]`,
+- `override_validator(Contracts::Func)` - e.g. `Func[Num => Num]`,
+- `override_validator(:valid)` - allows to override how contracts that respond to `:valid?` are handled,
+- `override_validator(:class)` - allows to override how class/module contract constants are handled,
+- `override_validator(:default)` - otherwise, raw value contracts.
+
+Default validators can be found here: [lib/contracts/validators.rb](https://github.com/egonSchiele/contracts.ruby/blob/master/lib/contracts/validators.rb).
+
 ## Disabling contracts
 
 If you want to disable contracts, set the `NO_CONTRACTS` environment variable. This will disable contracts and you won't have a performance hit. Pattern matching will still work if you disable contracts in this way! With NO_CONTRACTS only pattern-matching contracts are defined.

--- a/lib/contracts/call_with.rb
+++ b/lib/contracts/call_with.rb
@@ -1,0 +1,96 @@
+module Contracts
+  module CallWith
+    def call_with(this, *args, &blk)
+      args << blk if blk
+
+      # Explicitly append blk=nil if nil != Proc contract violation anticipated
+      maybe_append_block!(args, blk)
+
+      # Explicitly append options={} if Hash contract is present
+      maybe_append_options!(args, blk)
+
+      # Loop forward validating the arguments up to the splat (if there is one)
+      (@args_contract_index || args.size).times do |i|
+        contract = args_contracts[i]
+        arg = args[i]
+        validator = @args_validators[i]
+
+        unless validator && validator[arg]
+          return unless Contract.failure_callback(:arg => arg,
+                                                  :contract => contract,
+                                                  :class => klass,
+                                                  :method => method,
+                                                  :contracts => self,
+                                                  :arg_pos => i+1,
+                                                  :total_args => args.size,
+                                                  :return_value => false)
+        end
+
+        if contract.is_a?(Contracts::Func)
+          args[i] = Contract.new(klass, arg, *contract.contracts)
+        end
+      end
+
+      # If there is a splat loop backwards to the lower index of the splat
+      # Once we hit the splat in this direction set its upper index
+      # Keep validating but use this upper index to get the splat validator.
+      if @args_contract_index
+        splat_upper_index = @args_contract_index
+        (args.size - @args_contract_index).times do |i|
+          arg = args[args.size - 1 - i]
+
+          if args_contracts[args_contracts.size - 1 - i].is_a?(Contracts::Args)
+            splat_upper_index = i
+          end
+
+          # Each arg after the spat is found must use the splat validator
+          j = i < splat_upper_index ? i : splat_upper_index
+          contract = args_contracts[args_contracts.size - 1 - j]
+          validator = @args_validators[args_contracts.size - 1 - j]
+
+          unless validator && validator[arg]
+            return unless Contract.failure_callback(:arg => arg,
+                                                    :contract => contract,
+                                                    :class => klass,
+                                                    :method => method,
+                                                    :contracts => self,
+                                                    :arg_pos => i-1,
+                                                    :total_args => args.size,
+                                                    :return_value => false)
+          end
+
+          if contract.is_a?(Contracts::Func)
+            args[args.size - 1 - i] = Contract.new(klass, arg, *contract.contracts)
+          end
+        end
+      end
+
+      # If we put the block into args for validating, restore the args
+      args.slice!(-1) if blk
+      result = if method.respond_to?(:call)
+                 # proc, block, lambda, etc
+                 method.call(*args, &blk)
+               else
+                 # original method name referrence
+                 method.send_to(this, *args, &blk)
+               end
+
+      unless @ret_validator[result]
+        Contract.failure_callback(:arg => result,
+                                  :contract => ret_contract,
+                                  :class => klass,
+                                  :method => method,
+                                  :contracts => self,
+                                  :return_value => true)
+      end
+
+      this.verify_invariants!(method) if this.respond_to?(:verify_invariants!)
+
+      if ret_contract.is_a?(Contracts::Func)
+        result = Contract.new(klass, result, *ret_contract.contracts)
+      end
+
+      result
+    end
+  end
+end

--- a/lib/contracts/support.rb
+++ b/lib/contracts/support.rb
@@ -29,6 +29,10 @@ module Contracts
         (Time.now.to_f * 1000).to_i.to_s(36) + rand(1_000_000).to_s(36)
       end
 
+      def contract_id(contract)
+        contract.object_id
+      end
+
       def eigenclass_hierarchy_supported?
         return false if RUBY_PLATFORM == "java" && RUBY_VERSION.to_f < 2.0
         RUBY_VERSION.to_f > 1.8

--- a/lib/contracts/validators.rb
+++ b/lib/contracts/validators.rb
@@ -1,0 +1,101 @@
+module Contracts
+  module Validators
+    DEFAULT_VALIDATOR_STRATEGIES = {
+      # e.g. lambda {true}
+      Proc => lambda { |contract| contract },
+
+      # e.g. [Num, String]
+      # TODO: account for these errors too
+      Array => lambda do |contract|
+        lambda do |arg|
+          return false unless arg.is_a?(Array) && arg.length == contract.length
+          arg.zip(contract).all? do |_arg, _contract|
+            Contract.valid?(_arg, _contract)
+          end
+        end
+      end,
+
+      # e.g. { :a => Num, :b => String }
+      Hash => lambda do |contract|
+        lambda do |arg|
+          return false unless arg.is_a?(Hash)
+          contract.keys.all? do |k|
+            Contract.valid?(arg[k], contract[k])
+          end
+        end
+      end,
+
+      Contracts::Args => lambda do |contract|
+        lambda do |arg|
+          Contract.valid?(arg, contract.contract)
+        end
+      end,
+
+      Contracts::Func => lambda do |_|
+        lambda do |arg|
+          arg.is_a?(Method) || arg.is_a?(Proc)
+        end
+      end,
+
+      :valid => lambda do |contract|
+        lambda { |arg| contract.valid?(arg) }
+      end,
+
+      :class => lambda do |contract|
+        lambda { |arg| arg.is_a?(contract) }
+      end,
+
+      :default => lambda do |contract|
+        lambda { |arg| contract == arg }
+      end
+    }.freeze
+
+    # Allows to override validator with custom one.
+    # Example:
+    #   Contract.override_validator(Array) do |contract|
+    #     lambda do |arg|
+    #       # .. implementation for Array contract ..
+    #     end
+    #   end
+    #
+    #   Contract.override_validator(:class) do |contract|
+    #     lambda do |arg|
+    #       arg.is_a?(contract) || arg.is_a?(RSpec::Mocks::Double)
+    #     end
+    #   end
+    def override_validator(name, &block)
+      validator_strategies[name] = block
+    end
+
+    # This is a little weird. For each contract
+    # we pre-make a proc to validate it so we
+    # don't have to go through this decision tree every time.
+    # Seems silly but it saves us a bunch of time (4.3sec vs 5.2sec)
+    def make_validator(contract)
+      klass = contract.class
+      key = if validator_strategies.key?(klass)
+              klass
+            else
+              if contract.respond_to? :valid?
+                :valid
+              elsif klass == Class || klass == Module
+                :class
+              else
+                :default
+              end
+            end
+
+      validator_strategies[key].call(contract)
+    end
+
+    # @private
+    def validator_strategies
+      @_validator_strategies ||= restore_validators
+    end
+
+    # @private
+    def restore_validators
+      @_validator_strategies = DEFAULT_VALIDATOR_STRATEGIES.dup
+    end
+  end
+end

--- a/spec/override_validators_spec.rb
+++ b/spec/override_validators_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe Contract do
   describe ".override_validator" do
     around do |example|
-      Contract.restore_validators
+      Contract.reset_validators
       example.run
-      Contract.restore_validators
+      Contract.reset_validators
     end
 
     it "allows to override simple validators" do

--- a/spec/override_validators_spec.rb
+++ b/spec/override_validators_spec.rb
@@ -1,0 +1,162 @@
+RSpec.describe Contract do
+  describe ".override_validator" do
+    around do |example|
+      Contract.restore_validators
+      example.run
+      Contract.restore_validators
+    end
+
+    it "allows to override simple validators" do
+      Contract.override_validator(Hash) do |contract|
+        lambda do |arg|
+          return false unless arg.is_a?(Hash)
+          # Any hash in my system should have :it_is_a_hash key!
+          return false unless arg.key?(:it_is_a_hash)
+          contract.keys.all? do |k|
+            Contract.valid?(arg[k], contract[k])
+          end
+        end
+      end
+
+      klass = Class.new do
+        include Contracts
+
+        Contract ({ :a => Contracts::Num, :b => String }) => nil
+        def something(opts)
+          nil
+        end
+      end
+
+      obj = klass.new
+
+      expect do
+        obj.something(:a => 35, :b => "hello")
+      end.to raise_error(ContractError)
+
+      expect do
+        obj.something(
+          :a => 35,
+          :b => "hello",
+          :it_is_a_hash => true
+        )
+      end.not_to raise_error
+    end
+
+    it "allows to override valid contract" do
+      Contract.override_validator(:valid) do |contract|
+        if contract.respond_to?(:in_valid_state?)
+          lambda do |arg|
+            contract.in_valid_state? && contract.valid?(arg)
+          end
+        else
+          lambda { |arg| contract.valid?(arg) }
+        end
+      end
+
+      stateful_contract = Class.new(Contracts::CallableClass) do
+        def initialize(contract)
+          @contract = contract
+          @state = 0
+        end
+
+        def in_valid_state?
+          @state < 3
+        end
+
+        def valid?(arg)
+          @state += 1
+          Contract.valid?(arg, @contract)
+        end
+      end
+
+      klass = Class.new do
+        include Contracts
+
+        Contract stateful_contract[Contracts::Num] => Contracts::Num
+        def only_three_times(x)
+          x * x
+        end
+      end
+
+      obj = klass.new
+
+      expect(obj.only_three_times(3)).to eq(9)
+      expect(obj.only_three_times(3)).to eq(9)
+      expect(obj.only_three_times(3)).to eq(9)
+
+      expect do
+        obj.only_three_times(3)
+      end.to raise_error(ContractError)
+
+      expect do
+        obj.only_three_times(3)
+      end.to raise_error(ContractError)
+    end
+
+    it "allows to override class validator" do
+      # Make contracts accept all rspec doubles
+      Contract.override_validator(:class) do |contract|
+        lambda do |arg|
+          arg.is_a?(RSpec::Mocks::Double) ||
+            arg.is_a?(contract)
+        end
+      end
+
+      klass = Class.new do
+        include Contracts
+
+        Contract String => String
+        def greet(name)
+          "hello, #{name}"
+        end
+      end
+
+      obj = klass.new
+
+      expect(obj.greet("world")).to eq("hello, world")
+
+      expect do
+        obj.greet(4)
+      end.to raise_error(ContractError)
+
+      expect(obj.greet(double("name"))).to match(
+        /hello, #\[RSpec::Mocks::Double.+@name="name"\]/
+      )
+    end
+
+    it "allows to override default validator" do
+      spy = double("spy")
+
+      Contract.override_validator(:default) do |contract|
+        lambda do |arg|
+          spy.log("#{arg} == #{contract}")
+          arg == contract
+        end
+      end
+
+      klass = Class.new do
+        include Contracts
+
+        Contract 1, Contracts::Num => Contracts::Num
+        def gcd(_, b)
+          b
+        end
+
+        Contract Contracts::Num, Contracts::Num => Contracts::Num
+        def gcd(a, b)
+          gcd(b % a, a)
+        end
+      end
+
+      obj = klass.new
+
+      expect(spy).to receive(:log).with("8 == 1").ordered.once
+      expect(spy).to receive(:log).with("5 == 1").ordered.once
+      expect(spy).to receive(:log).with("3 == 1").ordered.once
+      expect(spy).to receive(:log).with("2 == 1").ordered.once
+      expect(spy).to receive(:log).with("1 == 1").ordered.once
+
+      obj.gcd(8, 5)
+    end
+  end
+end


### PR DESCRIPTION
- Extracted `#call_with` to its own module, without any changes to it.
- Extracted + Refactored `.make_validator` in its own module.
- Add ability to override validator strategies and add new ones (sort of, for user custom contracts)
- Make all calls to `Contract.make_validator` faster by memoizing

fixes #150 
fixes #156 

Example code for overriding `:class` strategy:

```ruby
require "rspec"
require "contracts"

Contract.override_validator(:class) do |contract|
  lambda do |arg|
    arg.is_a?(contract) || arg.is_a?(RSpec::Mocks::Double)
  end
end
```

@robnormal What do you think, can you use this kind of overriding mechanism?

/cc @egonSchiele Can you take a look at this one?