### PR TITLE
Update bundler before doing bundle install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,11 @@ rvm:
   - jruby-18mode # JRuby in 1.8 mode
   - jruby-19mode # JRuby in 1.9 mode
 
+before_install:
+  - gem install bundler
+
 script:
   - bundle exec rspec
   - ruby script/rubocop.rb
+
 bundler_args: --without development


### PR DESCRIPTION
Workaround for travis ruby 2.1 built-in bundler of being too old.

reference: https://github.com/travis-ci/travis-ci/issues/3531