### PR TITLE
Add Range validator

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -546,6 +546,7 @@ Possible validator overrides:
 - `override_validator(Proc)` - e.g. `lambda { true }`,
 - `override_validator(Array)` - e.g. `[Num, String]`,
 - `override_validator(Hash)` - e.g. `{ :a => Num, :b => String }`,
+- `override_validator(Range)` - e.g. `(1..10)`,
 - `override_validator(Contracts::Args)` - e.g. `Args[Num]`,
 - `override_validator(Contracts::Func)` - e.g. `Func[Num => Num]`,
 - `override_validator(:valid)` - allows to override how contracts that respond to `:valid?` are handled,

--- a/lib/contracts/validators.rb
+++ b/lib/contracts/validators.rb
@@ -25,6 +25,12 @@ module Contracts
         end
       end,
 
+      Range => lambda do |contract|
+        lambda do |arg|
+          contract.include?(arg)
+        end
+      end,
+
       Contracts::Args => lambda do |contract|
         lambda do |arg|
           Contract.valid?(arg, contract.contract)

--- a/spec/fixtures/fixtures.rb
+++ b/spec/fixtures/fixtures.rb
@@ -322,6 +322,10 @@ class GenericExample
     a
   end
 
+  Contract (1..10) => nil
+  def method_with_range_contract(x)
+  end
+
   Contract String
   def a_private_method
     "works"

--- a/spec/validators_spec.rb
+++ b/spec/validators_spec.rb
@@ -15,5 +15,11 @@ module Contracts
         o.method_with_range_contract(300)
       end.to raise_error(ContractError, /Expected: 1\.\.10/)
     end
+
+    it "fails when value is incorrect" do
+      expect do
+        o.method_with_range_contract("hello world")
+      end.to raise_error(ContractError, /Expected: 1\.\.10.*Actual: "hello world"/m)
+    end
   end
 end

--- a/spec/validators_spec.rb
+++ b/spec/validators_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+module Contracts
+  RSpec.describe "range contract validator" do
+    subject(:o) { GenericExample.new }
+
+    it "passes when value is in range" do
+      expect do
+        o.method_with_range_contract(5)
+      end.not_to raise_error(ContractError)
+    end
+
+    it "fails when value is not in range" do
+      expect do
+        o.method_with_range_contract(300)
+      end.to raise_error(ContractError, /Expected: 1\.\.10/)
+    end
+  end
+end


### PR DESCRIPTION
fixes #167 

Implemented first option:

```ruby
Contract (1..10) => String
def do_something(range)
```