### PR TITLE
Refactor :: Extract contracts core

### DIFF
--- a/lib/contracts.rb
+++ b/lib/contracts.rb
@@ -9,48 +9,15 @@ require "contracts/engine"
 require "contracts/method_handler"
 require "contracts/validators"
 require "contracts/call_with"
+require "contracts/core"
 
 module Contracts
   def self.included(base)
-    common(base)
+    base.send(:include, Core)
   end
 
   def self.extended(base)
-    common(base)
-  end
-
-  def self.common(base)
-    return if base.respond_to?(:Contract)
-
-    base.extend(MethodDecorators)
-
-    base.instance_eval do
-      def functype(funcname)
-        contracts = Engine.fetch_from(self).decorated_methods_for(:class_methods, funcname)
-        if contracts.nil?
-          "No contract for #{self}.#{funcname}"
-        else
-          "#{funcname} :: #{contracts[0]}"
-        end
-      end
-    end
-
-    base.class_eval do
-      # TODO: deprecate
-      # Required when contracts are included in global scope
-      def Contract(*args)
-        self.class.Contract(*args)
-      end
-
-      def functype(funcname)
-        contracts = Engine.fetch_from(self.class).decorated_methods_for(:instance_methods, funcname)
-        if contracts.nil?
-          "No contract for #{self.class}.#{funcname}"
-        else
-          "#{funcname} :: #{contracts[0]}"
-        end
-      end
-    end
+    base.send(:extend, Core)
   end
 end
 

--- a/lib/contracts/core.rb
+++ b/lib/contracts/core.rb
@@ -1,0 +1,45 @@
+module Contracts
+  module Core
+    def self.included(base)
+      common(base)
+    end
+
+    def self.extended(base)
+      common(base)
+    end
+
+    def self.common(base)
+      return if base.respond_to?(:Contract)
+
+      base.extend(MethodDecorators)
+
+      base.instance_eval do
+        def functype(funcname)
+          contracts = Engine.fetch_from(self).decorated_methods_for(:class_methods, funcname)
+          if contracts.nil?
+            "No contract for #{self}.#{funcname}"
+          else
+            "#{funcname} :: #{contracts[0]}"
+          end
+        end
+      end
+
+      base.class_eval do
+        # TODO: deprecate
+        # Required when contracts are included in global scope
+        def Contract(*args)
+          self.class.Contract(*args)
+        end
+
+        def functype(funcname)
+          contracts = Engine.fetch_from(self.class).decorated_methods_for(:instance_methods, funcname)
+          if contracts.nil?
+            "No contract for #{self.class}.#{funcname}"
+          else
+            "#{funcname} :: #{contracts[0]}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/builtin_contracts_spec.rb
+++ b/spec/builtin_contracts_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe "Contracts:" do
     end
 
     it "should fail for an object with both methods :good and :bad" do
-      expect { @o.xor_test(C.new) }.to raise_error(ContractError)
+      expect { @o.xor_test(F.new) }.to raise_error(ContractError)
     end
   end
 
@@ -160,7 +160,7 @@ RSpec.describe "Contracts:" do
     end
 
     it "should fail for an object that has a method :good but isn't of class A" do
-      expect { @o.and_test(C.new) }.to raise_error(ContractError)
+      expect { @o.and_test(F.new) }.to raise_error(ContractError)
     end
   end
 
@@ -190,7 +190,7 @@ RSpec.describe "Contracts:" do
     end
 
     it "should fail for an object that returns false for method :good" do
-      expect { @o.send_test(C.new) }.to raise_error(ContractError)
+      expect { @o.send_test(F.new) }.to raise_error(ContractError)
     end
   end
 
@@ -364,7 +364,7 @@ RSpec.describe "Contracts:" do
     it "doesn't allow to specify multiple key-value pairs with pretty syntax" do
       expect do
         Class.new do
-          include Contracts
+          include Contracts::Core
 
           Contract Contracts::HashOf[Symbol => String, Contracts::Num => Contracts::Num] => nil
           def something(hash)

--- a/spec/contracts_spec.rb
+++ b/spec/contracts_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe "Contracts:" do
   describe "anonymous classes" do
     let(:klass) do
       Class.new do
-        include Contracts
+        include Contracts::Core
 
         Contract String => String
         def greeting(name)
@@ -249,7 +249,7 @@ RSpec.describe "Contracts:" do
   describe "anonymous modules" do
     let(:mod) do
       Module.new do
-        include Contracts
+        include Contracts::Core
 
         Contract String => String
         def greeting(name)

--- a/spec/fixtures/fixtures.rb
+++ b/spec/fixtures/fixtures.rb
@@ -1,9 +1,11 @@
 require "date"
 
-class A
-  include Contracts
+C = Contracts
 
-  Contract Num => Num
+class A
+  include Contracts::Core
+
+  Contract C::Num => C::Num
   def self.a_class_method x
     x + 1
   end
@@ -12,12 +14,12 @@ class A
     true
   end
 
-  Contract Num => Num
+  Contract C::Num => C::Num
   def triple x
     x * 3
   end
 
-  Contract Num => Num
+  Contract C::Num => C::Num
   def instance_and_class_method x
     x * 2
   end
@@ -29,7 +31,7 @@ class A
 end
 
 class B
-  include Contracts
+  include Contracts::Core
 
   def bad
     false
@@ -41,8 +43,8 @@ class B
   end
 end
 
-class C
-  include Contracts
+class F
+  include Contracts::Core
 
   def good
     false
@@ -60,19 +62,19 @@ class EmptyCont
 end
 
 class GenericExample
-  include Contracts
+  include Contracts::Core
 
-  Contract Num => Num
+  Contract C::Num => C::Num
   def self.a_class_method x
     x + 1
   end
 
-  Contract Num => nil
+  Contract C::Num => nil
   def bad_double(x)
     x * 2
   end
 
-  Contract Num => Num
+  Contract C::Num => C::Num
   def double(x)
     x * 2
   end
@@ -86,12 +88,12 @@ class GenericExample
   def hello(name)
   end
 
-  Contract lambda { |x| x.is_a? Numeric } => Num
+  Contract lambda { |x| x.is_a? Numeric } => C::Num
   def square(x)
     x ** 2
   end
 
-  Contract [Num, Num, Num] => Num
+  Contract [C::Num, C::Num, C::Num] => C::Num
   def sum_three(vals)
     vals.inject(0) do |acc, x|
       acc + x
@@ -102,52 +104,52 @@ class GenericExample
   def person(data)
   end
 
-  Contract ({ :rigged => Or[TrueClass, FalseClass] }) => nil
+  Contract ({ :rigged => C::Or[TrueClass, FalseClass] }) => nil
   def hash_complex_contracts(data)
   end
 
-  Contract ({ :rigged => Bool,
-              :contents => { :kind => Or[String, Symbol],
-                             :total => Num }
+  Contract ({ :rigged => C::Bool,
+              :contents => { :kind => C::Or[String, Symbol],
+                             :total => C::Num }
             }) => nil
   def nested_hash_complex_contracts(data)
   end
 
-  Contract KeywordArgs[:name => String, :age => Fixnum] => nil
+  Contract C::KeywordArgs[:name => String, :age => Fixnum] => nil
   def person_keywordargs(data)
   end
 
-  Contract KeywordArgs[:hash => HashOf[Symbol, Num]] => nil
+  Contract C::KeywordArgs[:hash => C::HashOf[Symbol, C::Num]] => nil
   def hash_keywordargs(data)
   end
 
-  Contract [Or[TrueClass, FalseClass]] => nil
+  Contract [C::Or[TrueClass, FalseClass]] => nil
   def array_complex_contracts(data)
   end
 
-  Contract [Bool, [Or[String, Symbol]]] => nil
+  Contract [C::Bool, [C::Or[String, Symbol]]] => nil
   def nested_array_complex_contracts(data)
   end
 
-  Contract Proc => Any
+  Contract Proc => C::Any
   def do_call(&block)
     block.call
   end
 
-  Contract Args[Num], Maybe[Proc] => Any
+  Contract C::Args[C::Num], C::Maybe[Proc] => C::Any
   def maybe_call(*vals, &block)
     block.call if block
     vals
   end
 
-  Contract Args[Num] => Num
+  Contract C::Args[C::Num] => C::Num
   def sum(*vals)
     vals.inject(0) do |acc, val|
       acc + val
     end
   end
 
-  Contract Args[Num], Proc => Num
+  Contract C::Args[C::Num], Proc => C::Num
   def with_partial_sums(*vals, &blk)
     sum = vals.inject(0) do |acc, val|
       blk[acc]
@@ -156,7 +158,7 @@ class GenericExample
     blk[sum]
   end
 
-  Contract Args[Num], Func[Num => Num] => Num
+  Contract C::Args[C::Num], C::Func[C::Num => C::Num] => C::Num
   def with_partial_sums_contracted(*vals, &blk)
     sum = vals.inject(0) do |acc, val|
       blk[acc]
@@ -166,106 +168,106 @@ class GenericExample
   end
 
   # Important to use different arg types or it falsely passes
-  Contract Num, Args[String] => ArrayOf[String]
+  Contract C::Num, C::Args[String] => C::ArrayOf[String]
   def arg_then_splat(n, *vals)
     vals.map { |v| v * n }
   end
 
-  Contract Num, Proc => nil
+  Contract C::Num, Proc => nil
   def double_with_proc(x, &blk)
     blk.call(x * 2)
     nil
   end
 
-  Contract Pos => nil
+  Contract C::Pos => nil
   def pos_test(x)
   end
 
-  Contract Neg => nil
+  Contract C::Neg => nil
   def neg_test(x)
   end
 
-  Contract Nat => nil
+  Contract C::Nat => nil
   def nat_test(x)
   end
 
-  Contract Any => nil
+  Contract C::Any => nil
   def show(x)
   end
 
-  Contract None => nil
+  Contract C::None => nil
   def fail_all(x)
   end
 
-  Contract Or[Num, String] => nil
+  Contract C::Or[C::Num, String] => nil
   def num_or_string(x)
   end
 
-  Contract Xor[RespondTo[:good], RespondTo[:bad]] => nil
+  Contract C::Xor[C::RespondTo[:good], C::RespondTo[:bad]] => nil
   def xor_test(x)
   end
 
-  Contract And[A, RespondTo[:good]] => nil
+  Contract C::And[A, C::RespondTo[:good]] => nil
   def and_test(x)
   end
 
-  Contract Enum[:a, :b, :c] => nil
+  Contract C::Enum[:a, :b, :c] => nil
   def enum_test(x)
   end
 
-  Contract RespondTo[:good] => nil
+  Contract C::RespondTo[:good] => nil
   def responds_test(x)
   end
 
-  Contract Send[:good] => nil
+  Contract C::Send[:good] => nil
   def send_test(x)
   end
 
-  Contract Not[nil] => nil
+  Contract C::Not[nil] => nil
   def not_nil(x)
   end
 
-  Contract ArrayOf[Num] => Num
+  Contract C::ArrayOf[C::Num] => C::Num
   def product(vals)
     vals.inject(1) do |acc, x|
       acc * x
     end
   end
 
-  Contract SetOf[Num] => Num
+  Contract C::SetOf[C::Num] => C::Num
   def product_from_set(vals)
     vals.inject(1) do |acc, x|
       acc * x
     end
   end
 
-  Contract RangeOf[Num] => Num
+  Contract C::RangeOf[C::Num] => C::Num
   def first_in_range_num(r)
     r.first
   end
 
-  Contract RangeOf[Date] => Date
+  Contract C::RangeOf[Date] => Date
   def first_in_range_date(r)
     r.first
   end
 
-  Contract Bool => nil
+  Contract C::Bool => nil
   def bool_test(x)
   end
 
-  Contract Num
+  Contract C::Num
   def no_args
     1
   end
 
   # This function has a contract which says it has no args,
   # but the function does have args.
-  Contract nil => Num
+  Contract nil => C::Num
   def old_style_no_args
     2
   end
 
-  Contract ArrayOf[Num], Func[Num => Num] => ArrayOf[Num]
+  Contract C::ArrayOf[C::Num], C::Func[C::Num => C::Num] => C::ArrayOf[C::Num]
   def map(arr, func)
     ret = []
     arr.each do |x|
@@ -274,7 +276,7 @@ class GenericExample
     ret
   end
 
-  Contract ArrayOf[Any], Proc => ArrayOf[Any]
+  Contract C::ArrayOf[C::Any], Proc => C::ArrayOf[C::Any]
   def tutorial_map(arr, func)
     ret = []
     arr.each do |x|
@@ -285,29 +287,29 @@ class GenericExample
 
   # Need to test Func with weak contracts for other args
   # and changing type from input to output otherwise it falsely passes!
-  Contract Array, Func[String => Num] => Array
+  Contract Array, C::Func[String => C::Num] => Array
   def map_plain(arr, func)
     arr.map do |x|
       func[x]
     end
   end
 
-  Contract None => Func[String => Num]
+  Contract C::None => C::Func[String => C::Num]
   def lambda_with_wrong_return
     lambda { |x| x }
   end
 
-  Contract None => Func[String => Num]
+  Contract C::None => C::Func[String => C::Num]
   def lambda_with_correct_return
     lambda { |x| x.length }
   end
 
-  Contract Num => Num
+  Contract C::Num => C::Num
   def default_args(x = 1)
     2
   end
 
-  Contract Maybe[Num] => Maybe[Num]
+  Contract C::Maybe[C::Num] => C::Maybe[C::Num]
   def maybe_double x
     if x.nil?
       nil
@@ -316,17 +318,17 @@ class GenericExample
     end
   end
 
-  Contract HashOf[Symbol, Num] => Num
+  Contract C::HashOf[Symbol, C::Num] => C::Num
   def gives_max_value(hash)
     hash.values.max
   end
 
-  Contract HashOf[Symbol => Num] => Num
+  Contract C::HashOf[Symbol => C::Num] => C::Num
   def pretty_gives_max_value(hash)
     hash.values.max
   end
 
-  Contract EmptyCont => Any
+  Contract EmptyCont => C::Any
   def using_empty_contract(a)
     a
   end
@@ -364,9 +366,9 @@ end
 
 # for testing inheritance
 class Parent
-  include Contracts
+  include Contracts::Core
 
-  Contract Num => Num
+  Contract C::Num => C::Num
   def double x
     x * 2
   end
@@ -381,7 +383,7 @@ class GenericExample
     a
   end
 
-  Contract Exactly[Parent] => nil
+  Contract C::Exactly[Parent] => nil
   def exactly_test(x)
   end
 end
@@ -394,22 +396,22 @@ end
 Baz = 1
 
 class GenericExample
-  Contract Eq[Foo] => Any
+  Contract C::Eq[Foo] => C::Any
   def eq_class_test(x)
   end
 
-  Contract Eq[Bar] => Any
+  Contract C::Eq[Bar] => C::Any
   def eq_module_test(x)
   end
 
-  Contract Eq[Baz] => Any
+  Contract C::Eq[Baz] => C::Any
   def eq_value_test(x)
   end
 end
 
 # pattern matching example with possible deep contract violation
 class PatternMatchingExample
-  include Contracts
+  include Contracts::Core
 
   class Success
     attr_accessor :request
@@ -425,7 +427,7 @@ class PatternMatchingExample
   class Failure
   end
 
-  Response = Or[Success, Failure]
+  Response = C::Or[Success, Failure]
 
   class StringWithHello
     def self.valid?(string)
@@ -448,17 +450,17 @@ class PatternMatchingExample
     request + "!"
   end
 
-  Contract Num, String => String
+  Contract C::Num, String => String
   def do_stuff(number, string)
     "foo"
   end
 
-  Contract Num, String, Num => String
+  Contract C::Num, String, C::Num => String
   def do_stuff(number, string, other_number)
     "bar"
   end
 
-  Contract Num => Num
+  Contract C::Num => C::Num
   def double x
     "bad"
   end
@@ -471,7 +473,7 @@ end
 
 # invariant example (silliest implementation ever)
 class MyBirthday
-  include Contracts
+  include Contracts::Core
   include Contracts::Invariants
 
   invariant(:day) { 1 <= day && day <= 31 }
@@ -483,30 +485,30 @@ class MyBirthday
     @month = month
   end
 
-  Contract None => Fixnum
+  Contract C::None => Fixnum
   def silly_next_day!
     self.day += 1
   end
 
-  Contract None => Fixnum
+  Contract C::None => Fixnum
   def silly_next_month!
     self.month += 1
   end
 
-  Contract None => Fixnum
+  Contract C::None => Fixnum
   def clever_next_day!
     return clever_next_month! if day == 31
     self.day += 1
   end
 
-  Contract None => Fixnum
+  Contract C::None => Fixnum
   def clever_next_month!
     return next_year! if month == 12
     self.month += 1
     self.day = 1
   end
 
-  Contract None => Fixnum
+  Contract C::None => Fixnum
   def next_year!
     self.month = 1
     self.day = 1
@@ -517,7 +519,7 @@ class SingletonClassExample
   # This turned out to be required line here to make singleton classes
   # work properly under all platforms. Not sure if it worth trying to
   # do something with it.
-  include Contracts
+  include Contracts::Core
 
   class << self
     Contract String => String
@@ -525,7 +527,7 @@ class SingletonClassExample
       "super#{str}"
     end
 
-    Contract Num, Num => Num
+    Contract C::Num, C::Num => C::Num
     def add(a, b)
       a + b
     end
@@ -534,7 +536,7 @@ end
 
 with_enabled_no_contracts do
   class NoContractsSimpleExample
-    include Contracts
+    include Contracts::Core
 
     Contract String => nil
     def some_method(x)
@@ -543,21 +545,21 @@ with_enabled_no_contracts do
   end
 
   class NoContractsInvariantsExample
-    include Contracts
+    include Contracts::Core
     include Contracts::Invariants
 
     attr_accessor :day
 
     invariant(:day_rule) { 1 <= day && day <= 7 }
 
-    Contract None => nil
+    Contract C::None => nil
     def next_day
       self.day += 1
     end
   end
 
   class NoContractsPatternMatchingExample
-    include Contracts
+    include Contracts::Core
 
     Contract 200, String => String
     def on_response(status, body)
@@ -572,9 +574,9 @@ with_enabled_no_contracts do
 end
 
 module ModuleExample
-  include Contracts
+  include Contracts::Core
 
-  Contract Num, Num => Num
+  Contract C::Num, C::Num => C::Num
   def plus(a, b)
     a + b
   end
@@ -598,9 +600,9 @@ class KlassWithModuleExample
 end
 
 class SingletonInheritanceExample
-  include Contracts
+  include Contracts::Core
 
-  Contract Any => Any
+  Contract C::Any => C::Any
   def self.a_contracted_self
     self
   end
@@ -610,16 +612,16 @@ class SingletonInheritanceExampleSubclass < SingletonInheritanceExample
 end
 
 class BareOptionalContractUsed
-  include Contracts
+  include Contracts::Core
 
-  Contract Num, Optional[Num] => nil
+  Contract C::Num, C::Optional[C::Num] => nil
   def something(a, b)
     nil
   end
 end
 
 module ModuleContractExample
-  include Contracts
+  include Contracts::Core
 
   module AModule
   end

--- a/spec/module_spec.rb
+++ b/spec/module_spec.rb
@@ -1,7 +1,7 @@
 module Mod
-  include Contracts
+  include Contracts::Core
 
-  Contract Num => Num
+  Contract C::Num => C::Num
   def self.a_module_method a
     a + 1
   end

--- a/spec/override_validators_spec.rb
+++ b/spec/override_validators_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Contract do
       end
 
       klass = Class.new do
-        include Contracts
+        include Contracts::Core
 
         Contract ({ :a => Contracts::Num, :b => String }) => nil
         def something(opts)
@@ -70,7 +70,7 @@ RSpec.describe Contract do
       end
 
       klass = Class.new do
-        include Contracts
+        include Contracts::Core
 
         Contract stateful_contract[Contracts::Num] => Contracts::Num
         def only_three_times(x)
@@ -103,7 +103,7 @@ RSpec.describe Contract do
       end
 
       klass = Class.new do
-        include Contracts
+        include Contracts::Core
 
         Contract String => String
         def greet(name)
@@ -135,7 +135,7 @@ RSpec.describe Contract do
       end
 
       klass = Class.new do
-        include Contracts
+        include Contracts::Core
 
         Contract 1, Contracts::Num => Contracts::Num
         def gcd(_, b)

--- a/spec/ruby_version_specific/contracts_spec_1.9.rb
+++ b/spec/ruby_version_specific/contracts_spec_1.9.rb
@@ -1,11 +1,11 @@
 class GenericExample
-  Contract Args[String], Num => ArrayOf[String]
+  Contract C::Args[String], C::Num => C::ArrayOf[String]
   def splat_then_arg(*vals, n)
     vals.map { |v| v * n }
   end
 
   if ruby_version <= 1.9
-    Contract ({:foo => Nat}) => nil
+    Contract ({:foo => C::Nat}) => nil
     def nat_test_with_kwarg(a_hash)
     end
   end

--- a/spec/ruby_version_specific/contracts_spec_2.0.rb
+++ b/spec/ruby_version_specific/contracts_spec_2.0.rb
@@ -1,10 +1,10 @@
 class GenericExample
-  Contract Args[String], { repeat: Maybe[Num] } => ArrayOf[String]
+  Contract C::Args[String], { repeat: C::Maybe[C::Num] } => C::ArrayOf[String]
   def splat_then_optional_named(*vals, repeat: 2)
     vals.map { |v| v * repeat }
   end
 
-  Contract ({foo: Nat}) => nil
+  Contract ({foo: C::Nat}) => nil
   def nat_test_with_kwarg(foo: 10)
   end
 end

--- a/spec/ruby_version_specific/contracts_spec_2.1.rb
+++ b/spec/ruby_version_specific/contracts_spec_2.1.rb
@@ -1,6 +1,6 @@
 class GenericExample
-  Contract String, Bool, Args[Symbol], Float, KeywordArgs[e: Range, f: Optional[Num], g: Symbol], Proc =>
-           [Proc, Hash, Maybe[Num], Range, Float, ArrayOf[Symbol], Bool, String]
+  Contract String, C::Bool, C::Args[Symbol], Float, C::KeywordArgs[e: Range, f: C::Optional[C::Num], g: Symbol], Proc =>
+           [Proc, Hash, C::Maybe[C::Num], Range, Float, C::ArrayOf[Symbol], C::Bool, String]
   def complicated(a, b = true, *c, d, e:, f:2, **g, &h)
     h.call [h, g, f, e, d, c, b, a]
   end


### PR DESCRIPTION
This is a first stab on #157.

This refactoring does:

- Extracts `Contracts::Core` out of `Contracts`;
- Makes `include Contracts` include `Contracts::Core` for backwards compatibility;
- Factors out specs to use `Contracts::Core`;
- Makes `TUTORIAL.md` use `Contracts::Core` use it by default to encourage new users of contracts to use `include Contracts::Core` right away;
- Mentions shortcut `C = Contracts` in `TUTORIAL.md`.

/cc @egonSchiele @sfcgeorge @nixpulvis @robnormal 