### PR TITLE
Make KeywordArgs fail if unexpected keys are passed in

### DIFF
--- a/lib/contracts/builtin_contracts.rb
+++ b/lib/contracts/builtin_contracts.rb
@@ -385,6 +385,7 @@ module Contracts
     end
 
     def valid?(hash)
+      return false unless hash.keys - options.keys == []
       options.all? do |key, contract|
         Optional._valid?(hash, key, contract)
       end

--- a/spec/builtin_contracts_spec.rb
+++ b/spec/builtin_contracts_spec.rb
@@ -332,6 +332,24 @@ RSpec.describe "Contracts:" do
     end
   end
 
+  describe "KeywordArgs:" do
+    it "should pass for exact correct input" do
+      expect { @o.person_keywordargs(:name => "calvin", :age => 10) }.to_not raise_error
+    end
+
+    it "should fail if some keys don't have contracts" do
+      expect { @o.person_keywordargs(:name => "calvin", :age => 10, :foo => "bar") }.to raise_error(ContractError)
+    end
+
+    it "should fail if a key with a contract on it isn't provided" do
+      expect { @o.person_keywordargs(:name => "calvin") }.to raise_error(ContractError)
+    end
+
+    it "should fail for incorrect input" do
+      expect { @o.person_keywordargs(:name => 50, :age => 10) }.to raise_error(ContractError)
+    end
+  end
+
   describe "Optional:" do
     it "can't be used outside of KeywordArgs" do
       expect do

--- a/spec/fixtures/fixtures.rb
+++ b/spec/fixtures/fixtures.rb
@@ -113,6 +113,10 @@ class GenericExample
   def nested_hash_complex_contracts(data)
   end
 
+  Contract KeywordArgs[:name => String, :age => Fixnum] => nil
+  def person_keywordargs(data)
+  end
+
   Contract [Or[TrueClass, FalseClass]] => nil
   def array_complex_contracts(data)
   end

--- a/spec/ruby_version_specific/contracts_spec_2.1.rb
+++ b/spec/ruby_version_specific/contracts_spec_2.1.rb
@@ -1,5 +1,5 @@
 class GenericExample
-  Contract String, Bool, Args[Symbol], Float, KeywordArgs[e: Range, f: Optional[Num]], Proc =>
+  Contract String, Bool, Args[Symbol], Float, KeywordArgs[e: Range, f: Optional[Num], g: Symbol], Proc =>
            [Proc, Hash, Maybe[Num], Range, Float, ArrayOf[Symbol], Bool, String]
   def complicated(a, b = true, *c, d, e:, f:2, **g, &h)
     h.call [h, g, f, e, d, c, b, a]
@@ -15,7 +15,7 @@ RSpec.describe "Contracts:" do
     describe "really complicated method signature" do
       it "should work with default named args used" do
         expect do
-          @o.complicated("a", false, :b, 2.0, e: (1..5)) { |x| x }
+          @o.complicated("a", false, :b, 2.0, e: (1..5), g: :d) { |x| x }
         end.to_not raise_error
       end
 
@@ -56,7 +56,7 @@ RSpec.describe "Contracts:" do
           @o.complicated("a", true, :b, :c, 2.0, e: (1..5), f: nil, g: :d) do |x|
             x
           end
-        end.to raise_error(ContractError, /Expected: \(KeywordArgs\[{:e=>Range, :f=>Optional\[Num\]}\]\)/)
+        end.to raise_error(ContractError, /Expected: \(KeywordArgs\[{:e=>Range, :f=>Optional\[Num\], :g=>Symbol}\]\)/)
       end
     end
   end


### PR DESCRIPTION
Wasn't sure where to put the KeywordArgs specs - let me know if it should go in spec/contracts_spec.rb or whatnot (or if I'm otherwise way off base)