### PR TITLE
bug fix for varargs with a maybe[block]

### DIFF
--- a/lib/contracts.rb
+++ b/lib/contracts.rb
@@ -118,6 +118,7 @@ class Contract < Contracts::Decorator
     maybe_a_proc = last_contract.is_a?(Contracts::Maybe) && last_contract.include_proc?
 
     @has_proc_contract = is_a_proc || maybe_a_proc || last_contract.is_a?(Contracts::Func)
+
     # ====
 
     # == @has_options_contract
@@ -235,20 +236,24 @@ class Contract < Contracts::Decorator
 
   # a better way to handle this might be to take this into account
   # before throwing a "mismatched # of args" error.
+  # returns true if it appended nil
   def maybe_append_block! args, blk
-    return unless @has_proc_contract && !blk &&
+    return false unless @has_proc_contract && !blk &&
         (@args_contract_index || args.size < args_contracts.size)
     args << nil
+    true
   end
 
   # Same thing for when we have named params but didn't pass any in.
+  # returns true if it appended nil
   def maybe_append_options! args, blk
-    return unless @has_options_contract
+    return false unless @has_options_contract
     if @has_proc_contract && args_contracts[-2].is_a?(Hash) && !args[-2].is_a?(Hash)
       args.insert(-2, {})
     elsif args_contracts[-1].is_a?(Hash) && !args[-1].is_a?(Hash)
       args << {}
     end
+    true
   end
 
   # Used to determine type of failure exception this contract should raise in case of failure

--- a/lib/contracts/call_with.rb
+++ b/lib/contracts/call_with.rb
@@ -4,7 +4,7 @@ module Contracts
       args << blk if blk
 
       # Explicitly append blk=nil if nil != Proc contract violation anticipated
-      maybe_append_block!(args, blk)
+      nil_block_appended = maybe_append_block!(args, blk)
 
       # Explicitly append options={} if Hash contract is present
       maybe_append_options!(args, blk)
@@ -66,7 +66,8 @@ module Contracts
       end
 
       # If we put the block into args for validating, restore the args
-      args.slice!(-1) if blk
+      # OR if we added a fake nil at the end because a block wasn't passed in.
+      args.slice!(-1) if blk || nil_block_appended
       result = if method.respond_to?(:call)
                  # proc, block, lambda, etc
                  method.call(*args, &blk)

--- a/spec/contracts_spec.rb
+++ b/spec/contracts_spec.rb
@@ -423,6 +423,16 @@ RSpec.describe "Contracts:" do
         @o.maybe_call("bad")
       end.to raise_error(ContractError)
     end
+
+    describe "varargs are given with a maybe block" do
+      it "when a block is passed in, varargs should be correct" do
+        expect(@o.maybe_call(1, 2, 3) { 1 + 1 }).to eq([1, 2, 3])
+      end
+
+      it "when a block is NOT passed in, varargs should still be correct" do
+        expect(@o.maybe_call(1, 2, 3)).to eq([1, 2, 3])
+      end
+    end
   end
 
   describe "varargs" do

--- a/spec/fixtures/fixtures.rb
+++ b/spec/fixtures/fixtures.rb
@@ -133,6 +133,7 @@ class GenericExample
   Contract Args[Num], Maybe[Proc] => Any
   def maybe_call(*vals, &block)
     block.call if block
+    vals
   end
 
   Contract Args[Num] => Num


### PR DESCRIPTION
When varargs are given with a maybe[block], and the block is not provided, do not append an extra nil to the varargs (see waterlink's issue #161).

What do you think of this @waterlink ?