### PR TITLE
Do not allow non-hash values in HashOf contract

### DIFF
--- a/lib/contracts/builtin_contracts.rb
+++ b/lib/contracts/builtin_contracts.rb
@@ -360,6 +360,7 @@ module Contracts
     end
 
     def valid?(hash)
+      return false unless hash.is_a?(Hash)
       keys_match = hash.keys.map { |k| Contract.valid?(k, @key) }.all?
       vals_match = hash.values.map { |v| Contract.valid?(v, @value) }.all?
 

--- a/spec/builtin_contracts_spec.rb
+++ b/spec/builtin_contracts_spec.rb
@@ -347,6 +347,8 @@ RSpec.describe "Contracts:" do
 
     it "should fail for incorrect input" do
       expect { @o.person_keywordargs(:name => 50, :age => 10) }.to raise_error(ContractError)
+      expect { @o.hash_keywordargs(:hash => nil) }.to raise_error(ContractError)
+      expect { @o.hash_keywordargs(:hash => 1) }.to raise_error(ContractError)
     end
   end
 
@@ -379,6 +381,8 @@ RSpec.describe "Contracts:" do
 
     context "given an unfulfilled contract" do
       it { expect { @o.gives_max_value(:panda => "1", :bamboo => "2") }.to raise_error(ContractError) }
+      it { expect { @o.gives_max_value(nil) }.to raise_error(ContractError) }
+      it { expect { @o.gives_max_value(1) }.to raise_error(ContractError) }
       it { expect { @o.pretty_gives_max_value(:panda => "1", :bamboo => "2") }.to raise_error(ContractError) }
     end
 

--- a/spec/fixtures/fixtures.rb
+++ b/spec/fixtures/fixtures.rb
@@ -117,6 +117,10 @@ class GenericExample
   def person_keywordargs(data)
   end
 
+  Contract KeywordArgs[:hash => HashOf[Symbol, Num]] => nil
+  def hash_keywordargs(data)
+  end
+
   Contract [Or[TrueClass, FalseClass]] => nil
   def array_complex_contracts(data)
   end


### PR DESCRIPTION
Given these HashOf contracts:

```ruby
Contract HashOf[Symbol => String] => Any
def foo(args)
end

Contract KeywordArgs[:hash => HashOf[Symbol => String]] => Any
def bar(args)
end
```

calling `foo(nil)` or `bar(hash: nil)` results in `NoMethodError: undefined method ``keys' for nil:NilClass`