### PR TITLE
Add match-contract

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -271,6 +271,22 @@ give_largest_value(a: 1, b: 2, c: 3) # returns 3
 give_largest_value("a" => 1, 2 => 2, c: 3)
 ```
 
+### Contracts On Strings
+
+When you want a contract to match not just any string (i.e. `Contract String => nil`), you can use regular expressions:
+```ruby
+Contract /World|Mars/i => nil
+def greet(name)
+  puts "Hello #{name}!"
+end
+```
+
+Using logical combinations you can combine existing definitions, instead of writing 1 big regular expression:
+```ruby
+Contract C::And[default_mail_regexp, /#{AppConfig.domain}\z/] => nil
+def send_admin_invite(email)
+```
+
 ### Contracts On Keyword Arguments
 
 ruby 2.0+, but can be used for normal hashes too, when keyword arguments are
@@ -562,6 +578,7 @@ Possible validator overrides:
 - `override_validator(Array)` - e.g. `[C::Num, String]`,
 - `override_validator(Hash)` - e.g. `{ :a => C::Num, :b => String }`,
 - `override_validator(Range)` - e.g. `(1..10)`,
+- `override_validator(Regexp)` - e.g. `/foo/`,
 - `override_validator(Contracts::Args)` - e.g. `C::Args[C::Num]`,
 - `override_validator(Contracts::Func)` - e.g. `C::Func[C::Num => C::Num]`,
 - `override_validator(:valid)` - allows to override how contracts that respond to `:valid?` are handled,

--- a/lib/contracts/validators.rb
+++ b/lib/contracts/validators.rb
@@ -31,6 +31,12 @@ module Contracts
         end
       end,
 
+      Regexp => lambda do |contract|
+        lambda do |arg|
+          arg =~ contract
+        end
+      end,
+
       Contracts::Args => lambda do |contract|
         lambda do |arg|
           Contract.valid?(arg, contract.contract)

--- a/spec/fixtures/fixtures.rb
+++ b/spec/fixtures/fixtures.rb
@@ -123,6 +123,18 @@ class GenericExample
   def hash_keywordargs(data)
   end
 
+  Contract (/foo/) => nil
+  def should_contain_foo(s)
+  end
+
+  Contract ({ :host => /foo/ }) => nil
+  def hash_containing_foo(s)
+  end
+
+  Contract C::ArrayOf[/foo/] => nil
+  def array_containing_foo(s)
+  end
+
   Contract [C::Or[TrueClass, FalseClass]] => nil
   def array_complex_contracts(data)
   end

--- a/spec/validators_spec.rb
+++ b/spec/validators_spec.rb
@@ -1,9 +1,9 @@
 require "spec_helper"
 
-module Contracts
-  RSpec.describe "range contract validator" do
-    subject(:o) { GenericExample.new }
+RSpec.describe "Contract validators" do
+  subject(:o) { GenericExample.new }
 
+  describe "Range" do
     it "passes when value is in range" do
       expect do
         o.method_with_range_contract(5)
@@ -20,6 +20,28 @@ module Contracts
       expect do
         o.method_with_range_contract("hello world")
       end.to raise_error(ContractError, /Expected: 1\.\.10.*Actual: "hello world"/m)
+    end
+  end
+
+  describe "Regexp" do
+    it "should pass for a matching string" do
+      expect { o.should_contain_foo("containing foo") }.to_not raise_error
+    end
+
+    it "should fail for a non-matching string" do
+      expect { o.should_contain_foo("that's not F00") }.to raise_error(ContractError)
+    end
+
+    describe "within a hash" do
+      it "should pass for a matching string" do
+        expect { o.hash_containing_foo(:host => "foo.example.org") }.to_not raise_error
+      end
+    end
+
+    describe "within an array" do
+      it "should pass for a matching string" do
+        expect { o.array_containing_foo(["foo"]) }.to_not raise_error
+      end
     end
   end
 end


### PR DESCRIPTION
For a recent project this contract would have been handy:

```ruby
RGB = Match[/\#h{6}/] # e.g. '#ffffff'

Contract RGB => nil
def assign_color(color)
  # 
end
```

Other example:
```ruby
Contract Match[default_mail_regexp] => nil
def send_invitation(email)
...
```

As it's not easy to get the effect of a logical AND with regular expressions, so I added that as well:

```ruby
PartnerEmail = Match[default_mail_regexp, /(company1|company2)\.com\z/]

Contract PartnerEmail => nil
def invite_to_project(email)
```

Hopefully it's useful to others! If so I'm happy to move the explanation to the tutorial.