### PR TITLE
Fix classes that extend modules where contracts were included

### DIFF
--- a/lib/contracts/core.rb
+++ b/lib/contracts/core.rb
@@ -24,7 +24,10 @@ module Contracts
         end
       end
 
-      base.class_eval do
+      # NOTE: Workaround for `defined?(super)` bug in ruby 1.9.2
+      # source: http://stackoverflow.com/a/11181685
+      # bug: https://bugs.ruby-lang.org/issues/6644
+      base.class_eval <<-RUBY
         # TODO: deprecate
         # Required when contracts are included in global scope
         def Contract(*args)
@@ -34,7 +37,9 @@ module Contracts
             self.class.Contract(*args)
           end
         end
+      RUBY
 
+      base.class_eval do
         def functype(funcname)
           contracts = Engine.fetch_from(self.class).decorated_methods_for(:instance_methods, funcname)
           if contracts.nil?

--- a/lib/contracts/core.rb
+++ b/lib/contracts/core.rb
@@ -28,7 +28,11 @@ module Contracts
         # TODO: deprecate
         # Required when contracts are included in global scope
         def Contract(*args)
-          self.class.Contract(*args)
+          if defined?(super)
+            super
+          else
+            self.class.Contract(*args)
+          end
         end
 
         def functype(funcname)

--- a/spec/contracts_spec.rb
+++ b/spec/contracts_spec.rb
@@ -717,4 +717,33 @@ RSpec.describe "Contracts:" do
       expect { c.double("asd") }.to raise_error
     end
   end
+
+  describe "classes with extended modules" do
+    let(:klass) do
+      m = Module.new do
+        include Contracts::Core
+      end
+
+      Class.new do
+        include Contracts::Core
+        extend m
+
+        Contract String => nil
+        def foo(x)
+        end
+      end
+    end
+
+    it "is possible to define it" do
+      expect { klass }.not_to raise_error
+    end
+
+    it "works correctly with methods with passing contracts" do
+      expect { klass.new.foo("bar") }.not_to raise_error
+    end
+
+    it "works correctly with methods with passing contracts" do
+      expect { klass.new.foo(42) }.to raise_error(ContractError, /Expected: String/)
+    end
+  end
 end


### PR DESCRIPTION
Fixes #176 

Our current routine while including or extending `Contracts` is to define `Contract(*args)` method for current class and make it just delegate to `self.class.Contract`. But in case of:

```ruby
m = Module.new do
  include Contracts::Core
end

Class.new do
  include Contracts::Core
  extend m

  Contract String => nil
  def foo(x)
  end
end
```

it doesn't work, since there is no `self.class.Contract` at this point of time. But, there is just `Contract` already in super class, and we may just call it. That is what this PR does: verifies if there is a `Contract` method in super class and calls it instead of delegating to `self.class.Contract`.

/cc @PikachuEXE @egonSchiele 