### PR TITLE
Contracts on singleton classes of subclasses do not work

### DIFF
--- a/spec/contracts_spec.rb
+++ b/spec/contracts_spec.rb
@@ -176,6 +176,23 @@ RSpec.describe "Contracts:" do
     end
   end
 
+  describe "usage in the singleton class of a subclass" do
+    subject {
+      Class.new(GenericExample) do
+        class << self
+          Contract Integer => Integer
+          def num(int)
+            int
+          end
+        end
+      end
+    }
+
+    it "should work with a valid contract on a singleton method" do
+      expect(subject.num(1)).to eq(1)
+    end
+  end
+
   describe "no contracts feature" do
     it "disables normal contract checks" do
       object = NoContractsSimpleExample.new


### PR DESCRIPTION
Bug report in the form of a failing test.

Given:
```
class A
  include Contracts::Core
end

class B < A
  class << self
    Contract Integer => Integer
    def num(i); i; end
  end
end
```

You're going to get `Contracts::ContractsNotIncluded: In order to use contracts in singleton class, please include Contracts module in original class`