### PR TITLE
Spec behavior of mixing default values with blocks

### DIFF
--- a/spec/contracts_spec.rb
+++ b/spec/contracts_spec.rb
@@ -386,6 +386,30 @@ RSpec.describe "Contracts:" do
       end.to raise_error(ContractError, /Actual: nil/)
     end
 
+    it "should fail for lack of block when default used" do
+      expect do
+        @o.default_with_block
+      end.to raise_error(ContractError, /Actual: nil/)
+    end
+
+    it "should fail for lack of block when default overidden" do
+      expect do
+        @o.default_with_block(:arg)
+      end.to raise_error(ContractError, /Actual: nil/)
+    end
+
+    it "should succeed when default used and block given" do
+      expect do
+        @o.default_with_block() {}
+      end.to_not raise_error
+    end
+
+    it "should succeed when default overidden and block given" do
+      expect do
+        @o.default_with_block(:arg) {}
+      end.to_not raise_error
+    end
+
     it "should succeed for maybe proc with no proc" do
       expect do
         @o.maybe_call(5)

--- a/spec/contracts_spec.rb
+++ b/spec/contracts_spec.rb
@@ -383,32 +383,61 @@ RSpec.describe "Contracts:" do
     it "should handle properly lack of block when there are other arguments" do
       expect do
         @o.double_with_proc(4)
-      end.to raise_error(ContractError, /Actual: nil/)
+      end.to raise_error(ContractError, /Expected: Proc/)
     end
 
-    it "should fail for lack of block when default used" do
-      expect do
-        @o.default_with_block
-      end.to raise_error(ContractError, /Actual: nil/)
+    describe "and nil default values" do
+      it "should fail for lack of block when default used" do
+        expect do
+          @o.default_nil_with_block
+        end.to raise_error(ContractError, /Expected: Proc/)
+      end
+
+      it "should fail for lack of block when default overidden" do
+        expect do
+          @o.default_nil_with_block(:arg)
+        end.to raise_error(ContractError, /Expected: Proc/)
+      end
+
+      it "should succeed when default used and block given" do
+        expect do
+          @o.default_nil_with_block() {}
+        end.to_not raise_error
+      end
+
+      it "should succeed when default overidden and block given" do
+        expect do
+          @o.default_nil_with_block(:arg) {}
+        end.to_not raise_error
+      end
     end
 
-    it "should fail for lack of block when default overidden" do
-      expect do
-        @o.default_with_block(:arg)
-      end.to raise_error(ContractError, /Actual: nil/)
+    describe "and non-nil default values" do
+      it "should fail for lack of block when default used" do
+        expect do
+          @o.default_with_block
+        end.to raise_error(ContractError, /Expected: Proc/)
+      end
+
+      it "should fail for lack of block when default overidden" do
+        expect do
+          @o.default_with_block(:arg)
+        end.to raise_error(ContractError, /Actual: nil/)
+      end
+
+      it "should succeed when default used and block given" do
+        expect do
+          @o.default_with_block() {}
+        end.to_not raise_error
+      end
+
+      it "should succeed when default overidden and block given" do
+        expect do
+          @o.default_with_block(:arg) {}
+        end.to_not raise_error
+      end
     end
 
-    it "should succeed when default used and block given" do
-      expect do
-        @o.default_with_block() {}
-      end.to_not raise_error
-    end
-
-    it "should succeed when default overidden and block given" do
-      expect do
-        @o.default_with_block(:arg) {}
-      end.to_not raise_error
-    end
 
     it "should succeed for maybe proc with no proc" do
       expect do

--- a/spec/fixtures/fixtures.rb
+++ b/spec/fixtures/fixtures.rb
@@ -192,7 +192,11 @@ class GenericExample
   end
 
   Contract C::Maybe[Symbol], Proc => nil
-  def default_with_block(param = nil, &block)
+  def default_nil_with_block(param = nil, &block)
+  end
+
+  Contract Symbol, Proc => nil
+  def default_with_block(param = :default, &block)
   end
 
   Contract C::Pos => nil

--- a/spec/fixtures/fixtures.rb
+++ b/spec/fixtures/fixtures.rb
@@ -191,6 +191,10 @@ class GenericExample
     nil
   end
 
+  Contract C::Maybe[Symbol], Proc => nil
+  def default_with_block(param = nil, &block)
+  end
+
   Contract C::Pos => nil
   def pos_test(x)
   end


### PR DESCRIPTION
Default values and blocks don't mix well.  The specs added here show this.

I have added specs for both `nil default values` and `non-nil default values` because they fail differently in the `should fail for lack of block when default used` case.

Output from `bundle exec rake spec`:

```text
  1) Contracts: blocks and non-nil default values should succeed when default used and block given                                                                                                                                                                                 [78/1951]
     Failure/Error:
       expect do
         @o.default_with_block() {}
       end.to_not raise_error

       expected no Exception, got #<ParamContractError: Contract violation for argument 1 of 1:
               Expected: Symbol,
               Actual: #<Proc:0x00000601359560@/home/rfdonnelly/repos/contracts.ruby/spec/contracts_spec.rb:430>
               Value guarded in: GenericExample::default_with_block
               With Contract: Symbol, Proc => NilClass
               At: /home/rfdonnelly/repos/contracts.ruby/spec/fixtures/fixtures.rb:199 > with backtrace:
         # ./lib/contracts.rb:48:in `block in <class:Contract>'
         # ./lib/contracts.rb:154:in `call'
         # ./lib/contracts.rb:154:in `failure_callback'
         # ./lib/contracts/method_handler.rb:143:in `rescue in block in redefine_method'
         # ./lib/contracts/method_handler.rb:136:in `block in redefine_method'
         # ./spec/contracts_spec.rb:430:in `block (5 levels) in <top (required)>'
         # ./spec/contracts_spec.rb:429:in `block (4 levels) in <top (required)>'
     # ./spec/contracts_spec.rb:429:in `block (4 levels) in <top (required)>'

  2) Contracts: blocks and non-nil default values should fail for lack of block when default used
     Failure/Error:
       expect do
         @o.default_with_block
       end.to raise_error(ContractError, /Expected: Proc/)

       expected ContractError with message matching /Expected: Proc/, got #<ParamContractError: Contract violation for argument 1 of 1:
               Expected: Symbol,
               Actual: nil
               Value guarded in: GenericExample::default_with_block
               With Contract: Symbol, Proc => NilClass
               At: /home/rfdonnelly/repos/contracts.ruby/spec/fixtures/fixtures.rb:199 > with backtrace:
         # ./lib/contracts.rb:48:in `block in <class:Contract>'
         # ./lib/contracts.rb:154:in `call'
         # ./lib/contracts.rb:154:in `failure_callback'
         # ./lib/contracts/method_handler.rb:143:in `rescue in block in redefine_method'
         # ./lib/contracts/method_handler.rb:136:in `block in redefine_method'
         # ./spec/contracts_spec.rb:418:in `block (5 levels) in <top (required)>'
         # ./spec/contracts_spec.rb:417:in `block (4 levels) in <top (required)>'
     # ./spec/contracts_spec.rb:417:in `block (4 levels) in <top (required)>'

  3) Contracts: blocks and nil default values should fail for lack of block when default used
     Failure/Error:
       expect do
         @o.default_nil_with_block
       end.to raise_error(ContractError, /Expected: Proc/)

       expected ContractError with message matching /Expected: Proc/ but nothing was raised
     # ./spec/contracts_spec.rb:391:in `block (4 levels) in <top (required)>'

  4) Contracts: blocks and nil default values should succeed when default used and block given
     Failure/Error:
       expect do
         @o.default_nil_with_block() {}
       end.to_not raise_error

       expected no Exception, got #<ParamContractError: Contract violation for argument 1 of 1:
               Expected: (Symbol or nil),
               Actual: #<Proc:0x00000600f9e380@/home/rfdonnelly/repos/contracts.ruby/spec/contracts_spec.rb:404>
               Value guarded in: GenericExample::default_nil_with_block
               With Contract: Maybe, Proc => NilClass
               At: /home/rfdonnelly/repos/contracts.ruby/spec/fixtures/fixtures.rb:195 > with backtrace:
         # ./lib/contracts.rb:48:in `block in <class:Contract>'
         # ./lib/contracts.rb:154:in `call'
         # ./lib/contracts.rb:154:in `failure_callback'
         # ./lib/contracts/method_handler.rb:143:in `rescue in block in redefine_method'
         # ./lib/contracts/method_handler.rb:136:in `block in redefine_method'
         # ./spec/contracts_spec.rb:404:in `block (5 levels) in <top (required)>'
         # ./spec/contracts_spec.rb:403:in `block (4 levels) in <top (required)>'
     # ./spec/contracts_spec.rb:403:in `block (4 levels) in <top (required)>'
```