### PR TITLE
Release v0.13.0

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,5 +1,6 @@
 ## v0.13.0
 
+- Enhancement: Add support for Ruby 2.3 - [Oleksii Fedorov](https://github.com/waterlink) [#216](https://github.com/egonSchiele/contracts.ruby/pull/216)
 - Enhancement: Added Int, Nat and NatPos builtin contracts - [Simon George](https://github.com/sfcgeorge) [#212](https://github.com/egonSchiele/contracts.ruby/pull/212)
 - Bugfix: Allow contracts on singleton of subclass - [Oleksii Federov](https://github.com/waterlink) [#211](https://github.com/egonSchiele/contracts.ruby/pull/211)
 

--- a/lib/contracts/version.rb
+++ b/lib/contracts/version.rb
@@ -1,3 +1,3 @@
 module Contracts
-  VERSION = "0.12.0"
+  VERSION = "0.13.0"
 end


### PR DESCRIPTION
Closes #220 

This PR:
- Updates changelog with latest changes.
- Bumps up version to `v0.13.0`

/cc @egonSchiele Can you take a look?