### PR TITLE
Add syntax highlighting for error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ puts Example.new.double("oops")
 
 Save this in a file and run it. Notice we are calling `double` with `"oops"`, which is not a number. The contract fails with a detailed error message:
 
+```
 ParamContractError: Contract violation for argument 1 of 1:
         Expected: Num,
         Actual: "oops"
@@ -46,6 +47,7 @@ ParamContractError: Contract violation for argument 1 of 1:
         With Contract: Num => Num
         At: main.rb:8
         ...stack trace...
+```
 
 Instead of throwing an exception, you could log it, print a clean error message for your user...whatever you want. contracts.ruby is here to help you handle bugs better, not to get in your way.
 


### PR DESCRIPTION
Reason for change:
* The `README.md` was reading a bit weird without the syntax highlighting.

Change:
* Wrap the example error message in triple backticks.