### PR TITLE
Adds DescendantOf

### DIFF
--- a/lib/contracts/builtin_contracts.rb
+++ b/lib/contracts/builtin_contracts.rb
@@ -420,6 +420,30 @@ module Contracts
       attr_reader :options
     end
 
+    # Use this for specifying contracts for class arguments
+    # Example: <tt>Descendant[ e: Range, f: Optional[Num] ]</tt>
+    class DescendantOf < CallableClass
+      def initialize(parent_class)
+        @parent_class = parent_class
+      end
+
+      def valid?(given_class)
+        given_class.is_a?(Class) && given_class.ancestors.include?(parent_class)
+      end
+
+      def to_s
+        "DescendantOf[#{parent_class}]"
+      end
+
+      def inspect
+        to_s
+      end
+
+      private
+
+      attr_reader :parent_class
+    end
+
     # Use this for specifying optional keyword argument
     # Example: <tt>Optional[Num]</tt>
     class Optional < CallableClass

--- a/spec/builtin_contracts_spec.rb
+++ b/spec/builtin_contracts_spec.rb
@@ -3,6 +3,24 @@ RSpec.describe "Contracts:" do
     @o = GenericExample.new
   end
 
+  describe "DescendantOf:" do
+    it "should pass for Array" do
+      expect { @o.enumerable_descendant_test(Array) }.to_not raise_error
+    end
+
+    it "should pass for a hash" do
+      expect { @o.enumerable_descendant_test(Hash) }.to_not raise_error
+    end
+
+    it "should fail for a number class" do
+      expect { @o.enumerable_descendant_test(Integer) }.to raise_error(ContractError)
+    end
+
+    it "should fail for a non-class" do
+      expect { @o.enumerable_descendant_test(1) }.to raise_error(ContractError)
+    end
+  end
+
   describe "Num:" do
     it "should pass for Fixnums" do
       expect { @o.double(2) }.to_not raise_error

--- a/spec/fixtures/fixtures.rb
+++ b/spec/fixtures/fixtures.rb
@@ -263,6 +263,10 @@ class GenericExample
     r.first
   end
 
+  Contract C::DescendantOf[Enumerable] => nil
+  def enumerable_descendant_test(enum)
+  end
+
   Contract C::Bool => nil
   def bool_test(x)
   end


### PR DESCRIPTION
This adds the ability to make assertions on the class hierarchy of a class being passed as an argument. It should be useful when using things like the Adapter Pattern or Dependency Injection.

Consider the following example:

```ruby
class SlackClientAdapter < BaseClient
end

class HipchatClientAdapter < BaseClient
end

Contract C::DescendantOf[BaseClient] => BaseClient
def start_client(client_class)
  @client = client_class.new
end

start_client(SlackClientAdapter)
start_client(HipchatClientAdapter)
```

This is a demonstration of what I'm actually doing on a real app (although the example itself is totally made up).

I want to be able to assert that the argument is not just a class, but a descendant of `BaseClient` (this base client serves as an abstract class this example. God, I feel like a Java developer all over again...)

I'm not sure if this is something that's already been proposed and discarded, so I didn't take a lot of care in the organization of the code I added.
Should this be accepted, I'll gladly make any required changes before merging.