### PR TITLE
Adds rubocop in ruby 2.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ group :test do
   gem "rspec"
   gem "aruba"
   gem "cucumber", "~> 1.3.20"
-  gem "rubocop", "~> 0.29.1", :platform => [:ruby_20, :ruby_21, :ruby_22]
+  gem "rubocop", "~> 0.29.1", :platform => [:ruby_20, :ruby_21, :ruby_22, :ruby_23]
 end
 
 group :development do


### PR DESCRIPTION
The gemfile was limiting rubocop to only [2.0..2.2], so `rake` would
fail for me on 2.3