### PR TITLE
Fixed issue where KeywordArgs is not checked if it is a hash.

### DIFF
--- a/lib/contracts/builtin_contracts.rb
+++ b/lib/contracts/builtin_contracts.rb
@@ -401,6 +401,7 @@ module Contracts
       end
 
       def valid?(hash)
+        return false unless hash.is_a?(Hash)
         return false unless hash.keys - options.keys == []
         options.all? do |key, contract|
           Optional._valid?(hash, key, contract)

--- a/spec/builtin_contracts_spec.rb
+++ b/spec/builtin_contracts_spec.rb
@@ -368,6 +368,10 @@ RSpec.describe "Contracts:" do
       expect { @o.hash_keywordargs(:hash => nil) }.to raise_error(ContractError)
       expect { @o.hash_keywordargs(:hash => 1) }.to raise_error(ContractError)
     end
+
+    it "should pass if a method is overloaded with non-KeywordArgs" do
+      expect { @o.person_keywordargs("name", 10) }.to_not raise_error
+    end
   end
 
   describe "Optional:" do

--- a/spec/fixtures/fixtures.rb
+++ b/spec/fixtures/fixtures.rb
@@ -119,6 +119,11 @@ class GenericExample
   def person_keywordargs(data)
   end
 
+  # Testing overloaded method
+  Contract String, Fixnum => nil
+  def person_keywordargs(name, age)
+  end
+
   Contract C::KeywordArgs[:hash => C::HashOf[Symbol, C::Num]] => nil
   def hash_keywordargs(data)
   end


### PR DESCRIPTION
This leads to issues when methods are overloaded, because when the
KeywordArgs gets checked on a non-hash argument, it raises an exception
rather than failing properly.