### PR TITLE
StrictHash

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -89,6 +89,7 @@ contracts.ruby comes with a lot of built-in contracts, including the following:
   * [`ArrayOf`](http://www.rubydoc.info/gems/contracts/Contracts/Builtin/ArrayOf) – checks that the argument is an array, and all elements pass the given contract, e.g. `ArrayOf[Num]`
   * [`SetOf`](http://www.rubydoc.info/gems/contracts/Contracts/Builtin/SetOf) – checks that the argument is a set, and all elements pass the given contract, e.g. `SetOf[Num]`
   * [`HashOf`](http://www.rubydoc.info/gems/contracts/Contracts/Builtin/HashOf) – checks that the argument is a hash, and all keys and values pass the given contract, e.g. `HashOf[Symbol => String]` or `HashOf[Symbol,String]`
+  * [`StrictHash`](http://www.rubydoc.info/gems/contracts/Contracts/Builtin/StrictHash) – checks that the argument is a hash, and every key passed is present in the given contract, e.g. `StrictHash[{ :description => String, :number => Fixnum }]`
   * [`RangeOf`](http://www.rubydoc.info/gems/contracts/Contracts/Builtin/RangeOf) – checks that the argument is a range whose elements (#first and #last) pass the given contract, e.g. `RangeOf[Date]`
   * [`Enum`](http://www.rubydoc.info/gems/contracts/Contracts/Builtin/Enum) – checks that the argument is part of a given collection of objects, e.g. `Enum[:a, :b, :c]`
 
@@ -270,7 +271,7 @@ You don't need to put a contract on every key. So this call would succeed:
 person({:name => "Adit", :age => 42, :foo => "bar"})
 ```
 
-even though we don't specify a type for `:foo`.
+even though we don't specify a type for `:foo`. If you need this check though, use `StrictHash` instead.
 
 Peruse this contract on the keys and values of a Hash.
 

--- a/lib/contracts/builtin_contracts.rb
+++ b/lib/contracts/builtin_contracts.rb
@@ -393,6 +393,25 @@ module Contracts
       end
     end
 
+    # Use this to specify the Hash characteristics. This contracts fails
+    # if there are any extra keys that don't have contracts on them.
+    # Example: <tt>StrictHash[{ a: String, b: Bool }]</tt>
+    class StrictHash < CallableClass
+      attr_reader :contract_hash
+
+      def initialize(contract_hash)
+        @contract_hash = contract_hash
+      end
+
+      def valid?(arg)
+        return false unless arg.is_a?(Hash)
+
+        contract_hash.all? do |key, _v|
+          contract_hash.key?(key) && Contract.valid?(arg[key], contract_hash[key])
+        end
+      end
+    end
+
     # Use this for specifying contracts for keyword arguments
     # Example: <tt>KeywordArgs[ e: Range, f: Optional[Num] ]</tt>
     class KeywordArgs < CallableClass

--- a/spec/builtin_contracts_spec.rb
+++ b/spec/builtin_contracts_spec.rb
@@ -418,4 +418,44 @@ RSpec.describe "Contracts:" do
       end
     end
   end
+
+  describe "StrictHash:" do
+    context "when given an exact correct input" do
+      it "does not raise an error" do
+        expect do
+          @o.strict_person(:name => "calvin", :age => 10)
+        end.to_not raise_error
+      end
+    end
+
+    context "when given an input with correct keys but wrong types" do
+      it "raises an error" do
+        expect do
+          @o.strict_person(:name => "calvin", :age => "10")
+        end.to raise_error(ContractError)
+      end
+    end
+
+    context "when given an input with missing keys" do
+      it "raises an error" do
+        expect do
+          @o.strict_person(:name => "calvin")
+        end.to raise_error(ContractError)
+      end
+    end
+
+    context "when given an input with extra keys" do
+      it "raises an error" do
+        expect do
+          @o.strict_person(:name => "calvin", :age => "10", :soft => true)
+        end.to raise_error(ContractError)
+      end
+    end
+
+    context "when given not a hash" do
+      it "raises an error" do
+        expect { @o.strict_person(1337) }.to raise_error(ContractError)
+      end
+    end
+  end
 end

--- a/spec/fixtures/fixtures.rb
+++ b/spec/fixtures/fixtures.rb
@@ -104,6 +104,10 @@ class GenericExample
   def person(data)
   end
 
+  Contract C::StrictHash[{ :name => String, :age => Fixnum }] => nil
+  def strict_person(data)
+  end
+
   Contract ({ :rigged => C::Or[TrueClass, FalseClass] }) => nil
   def hash_complex_contracts(data)
   end


### PR DESCRIPTION
Adds a StrictHash builtin contract, which checks that the argument is
a hash, and every key passed is present in the given contract.

https://github.com/egonSchiele/contracts.ruby/issues/235