### PR TITLE
Fix contracts used in AR-models

### DIFF
--- a/lib/contracts/decorators.rb
+++ b/lib/contracts/decorators.rb
@@ -6,6 +6,7 @@ module Contracts
 
     def inherited(subclass)
       Engine.fetch_from(subclass).set_eigenclass_owner
+      super
     end
 
     def method_added(name)


### PR DESCRIPTION
ActiveRecord::Base.inherited needs to be called in order for models to be setup correctly.

Fixes #223