### PR TITLE
custom error formatter for KeywordArgs

### DIFF
--- a/lib/contracts.rb
+++ b/lib/contracts.rb
@@ -1,6 +1,7 @@
 require "contracts/builtin_contracts"
 require "contracts/decorators"
 require "contracts/errors"
+require "contracts/error_formatter"
 require "contracts/formatters"
 require "contracts/invariants"
 require "contracts/method_reference"
@@ -115,22 +116,7 @@ class Contract < Contracts::Decorator
   # This function is used by the default #failure_callback method
   # and uses the hash passed into the failure_callback method.
   def self.failure_msg(data)
-    expected = Contracts::Formatters::Expected.new(data[:contract]).contract
-    position = Contracts::Support.method_position(data[:method])
-    method_name = Contracts::Support.method_name(data[:method])
-
-    header = if data[:return_value]
-               "Contract violation for return value:"
-             else
-               "Contract violation for argument #{data[:arg_pos]} of #{data[:total_args]}:"
-             end
-
-    %{#{header}
-        Expected: #{expected},
-        Actual: #{data[:arg].inspect}
-        Value guarded in: #{data[:class]}::#{method_name}
-        With Contract: #{data[:contracts]}
-        At: #{position} }
+    Contracts::ErrorFormatters.failure_msg(data)
   end
 
   # Callback for when a contract fails. By default it raises

--- a/lib/contracts/error_formatter.rb
+++ b/lib/contracts/error_formatter.rb
@@ -1,0 +1,124 @@
+module Contracts
+  class ErrorFormatters
+    def self.failure_msg(data)
+      class_for(data).new(data).message
+    end
+
+    def self.class_for(data)
+      return Contracts::KeywordArgsErrorFormatter if is_keysword_args?(data)
+      return DefaultErrorFormatter
+    end
+
+    def self.is_keysword_args?(data)
+      data[:contract].is_a?(Contracts::Builtin::KeywordArgs) && data[:arg].is_a?(Hash)
+    end
+  end
+
+  class DefaultErrorFormatter
+    include Contracts::Colorize
+    attr_accessor :data
+    def initialize(data)
+      @data = data
+    end
+
+    def message
+      %{#{header}
+        Expected: #{expected},
+        Actual: #{data[:arg].inspect}
+        Value guarded in: #{data[:class]}::#{method_name}
+        With Contract: #{data[:contracts]}
+        At: #{green(position)} }
+    end
+
+  private
+    def header
+      if data[:return_value]
+         "Contract violation for return value:"
+       else
+         "Contract violation for argument #{data[:arg_pos]} of #{data[:total_args]}:"
+       end
+    end
+
+    def expected
+      Contracts::Formatters::Expected.new(data[:contract]).contract
+    end
+
+    def position
+      Contracts::Support.method_position(data[:method])
+    end
+
+    def method_name
+      Contracts::Support.method_name(data[:method])
+    end
+  end
+
+  class KeywordArgsErrorFormatter < DefaultErrorFormatter
+    def message
+      s = []
+      s << header
+      s << "Expected: #{expected}"
+      s << "Actual: #{data[:arg].inspect}"
+      s << "Missing Contract: #{missing_contract_info}" if !missing_contract_info.empty?
+      s << "Invalid Args: #{invalid_args_info}"         if !invalid_args_info.empty?
+      s << "Missing Args: #{missing_args_info}"         if !missing_args_info.empty?
+      s << "Value guarded in: #{data[:class]}::#{method_name}"
+      s << "With Contract: #{data[:contracts]}"
+      s << "At: #{position}"
+
+      s.join("\n")
+    end
+
+    private
+
+    def missing_args_info
+      @missing_args_info ||= begin
+        missing_keys = contract_options.keys - arg.keys
+        contract_options.select do |key, value|
+          missing_keys.include?(key)
+        end
+      end
+    end
+
+    def missing_contract_info
+      @missing_contract_info ||= begin
+        contract_keys = contract_options.keys
+        arg.select{|key, value| !contract_keys.include?(key)}
+      end
+    end
+
+    def invalid_args_info
+      @invalid_args_info ||= begin
+        invalid_keys = []
+        arg.each do |key, value|
+          if contract = contract_options[key]
+            if !(check_contract(contract, value))
+              invalid_keys.push(key)
+            end
+          end
+        end
+        invalid_keys.map do |key|
+          {key => arg[key], :contract => contract_options[key] }
+        end
+      end
+    end
+
+    def check_contract(contract, value)
+      if contract.respond_to?(:valid?)
+        contract.valid?(value)
+      else
+        value.is_a?(contract)
+      end
+    rescue
+      false
+    end
+
+
+    def contract_options
+      @contract_options ||= data[:contract].send(:options)
+    end
+
+    def arg
+      data[:arg]
+    end
+  end
+end

--- a/spec/error_formatter_spec.rb
+++ b/spec/error_formatter_spec.rb
@@ -1,0 +1,64 @@
+RSpec.describe "Contracts::ErrorFormatters" do
+  before :all do
+    @o = GenericExample.new
+  end
+
+  describe "self.class_for" do
+    it "returns the right formatter for passed in data" do
+    end
+  end
+
+  def format_message(str)
+    str.split("\n").map(&:strip).join("\n")
+  end
+
+  describe "self.failure_msg" do
+    it "includes normal information" do
+      expect do
+        @o.simple_keywordargs(age: "2", invalid_third: 1)
+      end.to raise_error do |e|
+        error_msg = %Q{Contract violation for argument 1 of 1:
+Expected: (KeywordArgs[{:name=>String, :age=>Fixnum}])
+Actual: {:age=>"2", :invalid_third=>1}
+Missing Contract: {:invalid_third=>1}
+Invalid Args: [{:age=>"2", :contract=>Fixnum}]
+Missing Args: {:name=>String}
+Value guarded in: GenericExample::simple_keywordargs
+With Contract: KeywordArgs => NilClass}
+
+        expect(e.class).to eq(ParamContractError)
+        expect(format_message(e.message)).to include(format_message(error_msg))
+      end
+    end
+
+    it "includes Missing Contract information" do
+      expect do
+        @o.simple_keywordargs(age: "2", invalid_third: 1, invalid_fourth: 1)
+      end.to raise_error do |e|
+        diff_msg = %Q{Missing Contract: {:invalid_third=>1, :invalid_fourth=>1}}
+        expect(e.class).to eq(ParamContractError)
+        expect(e.message).to include(diff_msg)
+      end
+    end
+
+    it "includes Invalid Args information" do
+      expect do
+        @o.simple_keywordargs(age: "2", invalid_third: 1)
+      end.to raise_error do |e|
+        diff_msg = %Q{Invalid Args: [{:age=>"2", :contract=>Fixnum}]}
+        expect(e.class).to eq(ParamContractError)
+        expect(e.message).to include(diff_msg)
+      end
+    end
+
+    it "includes Missing Args information" do
+      expect do
+        @o.simple_keywordargs(age: "2", invalid_third: 1)
+      end.to raise_error do |e|
+        diff_msg = %Q{Missing Args: {:name=>String}}
+        expect(e.class).to eq(ParamContractError)
+        expect(e.message).to include(diff_msg)
+      end
+    end
+  end
+end

--- a/spec/fixtures/fixtures.rb
+++ b/spec/fixtures/fixtures.rb
@@ -132,6 +132,11 @@ class GenericExample
   def hash_keywordargs(data)
   end
 
+  Contract C::KeywordArgs[:name => String, :age => Fixnum] => nil
+  def simple_keywordargs(name:, age:)
+  end
+
+
   Contract (/foo/) => nil
   def should_contain_foo(s)
   end


### PR DESCRIPTION
problem: 
- it is impossible to quickly understand the contract violation with big hashes 

solution: 
- provide custom error formatter just for keywordargs, that gives you extra information about: 
- Missing Contract definition (for unspecified keys in contract)
- Invalid Args (validation failures)
- Missing Args (required values, that are missing)