### PR TITLE
Fix StrictHash contract for extra keys

### DIFF
--- a/lib/contracts/builtin_contracts.rb
+++ b/lib/contracts/builtin_contracts.rb
@@ -407,8 +407,8 @@ module Contracts
         return false unless arg.is_a?(Hash)
         return false unless arg.keys.sort.eql?(contract_hash.keys.sort)
 
-        contract_hash.all? do |key, _v|
-          contract_hash.key?(key) && Contract.valid?(arg[key], contract_hash[key])
+        contract_hash.all? do |key, contract|
+          contract_hash.key?(key) && Contract.valid?(arg[key], contract)
         end
       end
     end

--- a/lib/contracts/builtin_contracts.rb
+++ b/lib/contracts/builtin_contracts.rb
@@ -405,6 +405,7 @@ module Contracts
 
       def valid?(arg)
         return false unless arg.is_a?(Hash)
+        return false unless arg.keys.sort.eql?(contract_hash.keys.sort)
 
         contract_hash.all? do |key, _v|
           contract_hash.key?(key) && Contract.valid?(arg[key], contract_hash[key])

--- a/spec/builtin_contracts_spec.rb
+++ b/spec/builtin_contracts_spec.rb
@@ -448,7 +448,7 @@ RSpec.describe "Contracts:" do
 
     context "when given an input with extra keys" do
       it "raises an error" do
-        fails { @o.strict_person(:name => "calvin", :age => "10", :soft => true) }
+        fails { @o.strict_person(:name => "calvin", :age => 10, :soft => true) }
       end
     end
 


### PR DESCRIPTION
`Contracts::StrictHash` didn't complain about extra entries in a given
hash. This was because of the missing assertion for keys. Specs hadn't
caught this case because `age` key had a wrong type anyway.

Compare keys for contract and a given hash and return false if they are
equal.