### PR TITLE
Add a `Contracts::Attrs` module containing attribute w/ contracts utilities.

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -606,6 +606,32 @@ Possible validator overrides:
 
 Default validators can be found here: [lib/contracts/validators.rb](https://github.com/egonSchiele/contracts.ruby/blob/master/lib/contracts/validators.rb).
 
+## Contracts with attributes
+
+You can include the `Contracts::Attrs` module in your class/module to get access to attribute utilities:
+
+- `attr_reader_with_contract <symbol>..., <contract>`
+  - Wraps `attr_reader`, validates contract upon 'getting'
+- `attr_writer_with_contract <symbol>..., <contract>`
+  - Wraps `attr_writer`, validates contract upon 'setting'
+- `attr_accessor_with_contract <symbol>..., <contract>`
+  - Wraps `attr_accessor`, validates contract upon 'getting' or 'setting'
+
+### Example
+
+```ruby
+class Person
+  include Contracts::Core
+  include Contracts::Attrs
+
+  attr_accessor_with_contract :name, String
+end
+
+person = Person.new
+person.name = 'Jane'
+person.name = 1.4 # This results in a contract error!
+```
+
 ## Disabling contracts
 
 If you want to disable contracts, set the `NO_CONTRACTS` environment variable. This will disable contracts and you won't have a performance hit. Pattern matching will still work if you disable contracts in this way! With NO_CONTRACTS only pattern-matching contracts are defined.

--- a/lib/contracts.rb
+++ b/lib/contracts.rb
@@ -1,3 +1,4 @@
+require "contracts/attrs"
 require "contracts/builtin_contracts"
 require "contracts/decorators"
 require "contracts/errors"

--- a/lib/contracts/attrs.rb
+++ b/lib/contracts/attrs.rb
@@ -1,0 +1,20 @@
+module Contracts
+  module Attrs
+    def attr_reader_with_contract(*names, contract)
+      Contract Contracts::None => contract
+      attr_reader(*names)
+    end
+
+    def attr_writer_with_contract(*names, contract)
+      Contract contract => contract
+      attr_writer(*names)
+    end
+
+    def attr_accessor_with_contract(*names, contract)
+      attr_reader_with_contract(*names, contract)
+      attr_writer_with_contract(*names, contract)
+    end
+  end
+
+  include Attrs
+end

--- a/spec/attrs_spec.rb
+++ b/spec/attrs_spec.rb
@@ -1,0 +1,75 @@
+RSpec.describe "Contracts:" do
+  describe "Attrs:" do
+    class Person
+      include Contracts::Core
+      include Contracts::Attrs
+      include Contracts::Builtin
+
+      def initialize(name)
+        @name_r = name
+        @name_w = name
+        @name_rw = name
+      end
+
+      attr_reader_with_contract :name_r, String
+      attr_writer_with_contract :name_w, String
+      attr_accessor_with_contract :name_rw, String
+    end
+
+    context "attr_reader_with_contract" do
+      it "getting valid type" do
+        expect(Person.new("bob").name_r)
+          .to(eq("bob"))
+      end
+
+      it "getting invalid type" do
+        expect { Person.new(1.3).name_r }
+          .to(raise_error(ReturnContractError))
+      end
+
+      it "setting" do
+        expect { Person.new("bob").name_r = "alice" }
+          .to(raise_error(NoMethodError))
+      end
+    end
+
+    context "attr_writer_with_contract" do
+      it "getting" do
+        expect { Person.new("bob").name_w }
+          .to(raise_error(NoMethodError))
+      end
+
+      it "setting valid type" do
+        expect(Person.new("bob").name_w = "alice")
+          .to(eq("alice"))
+      end
+
+      it "setting invalid type" do
+        expect { Person.new("bob").name_w = 1.2 }
+          .to(raise_error(ParamContractError))
+      end
+    end
+
+    context "attr_accessor_with_contract" do
+      it "getting valid type" do
+        expect(Person.new("bob").name_rw)
+          .to(eq("bob"))
+      end
+
+      it "getting invalid type" do
+        expect { Person.new(1.2).name_rw }
+          .to(raise_error(ReturnContractError))
+      end
+
+      it "setting valid type" do
+        expect(Person.new("bob").name_rw = "alice")
+          .to(eq("alice"))
+      end
+
+      it "setting invalid type" do
+        expect { Person.new("bob").name_rw = 1.2 }
+          .to(raise_error(ParamContractError))
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds a new module `Contracts::Attrs` containing three methods to assist in using contracts with object attributes:

- `attr_reader_with_contract <symbol>..., <contract>`
  - Wraps `attr_reader`, validates contract upon 'getting'
- `attr_writer_with_contract <symbol>..., <contract>`
  - Wraps `attr_writer`, validates contract upon 'setting'
- `attr_accessor_with_contract <symbol>..., <contract>`
  - Wraps `attr_accessor`, validates contract upon 'getting' or 'setting'