### PR TITLE
Drop support for Ruby 1.8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,7 @@ bundler_args: --without development
 
 matrix:
   include:
-    - rvm: "1.8.7"
-      dist: precise
     - rvm: "1.9.2"
-      dist: precise
-    - rvm: jruby-18mode # JRuby in 1.8 mode
       dist: precise
     - rvm: jruby-19mode # JRuby in 1.9 mode
       dist: precise

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+## v0.16.0 (unreleased)
+
+- Support for Ruby 1.8 has been discontinued - [#256](https://github.com/egonSchiele/contracts.ruby/pull/256)
+
 ## v0.15.0
 - Bugfix: Func contract's return value isn't enforced with blocks - [Piotr Szmielew](https://github.com/esse) [#251](https://github.com/egonSchiele/contracts.ruby/pull/251)
 - Bugfx: Fix contracts used in AR-models - [Gert Goet](https://github.com/eval) [#237](https://github.com/egonSchiele/contracts.ruby/pull/237)

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Using contracts.ruby results in very little slowdown. Check out [this blog post]
 
 **Q.** What Rubies can I use this with?
 
-**A.** It's been tested with `1.8.7`, `1.9.2`, `1.9.3`, `2.0.0`, `2.1`, `2.2`, and `jruby` (both 1.8 and 1.9 modes).
+**A.** It's been tested with `1.9.2`, `1.9.3`, `2.0.0`, `2.1`, `2.2`, and `jruby` (1.9 mode).
 
 If you're using the library, please [let me know](https://github.com/egonSchiele) what project you're using it on :)
 

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,6 @@ else
   task :default => [:spec]
 end
 
-
 task :add_tag do
   `git tag -a v#{Contracts::VERSION} -m 'v#{Contracts::VERSION}'`
 end

--- a/lib/contracts/support.rb
+++ b/lib/contracts/support.rb
@@ -4,16 +4,8 @@ module Contracts
       def method_position(method)
         return method.method_position if method.is_a?(MethodReference)
 
-        if RUBY_VERSION =~ /^1\.8/
-          if method.respond_to?(:__file__)
-            method.__file__ + ":" + method.__line__.to_s
-          else
-            method.inspect
-          end
-        else
-          file, line = method.source_location
-          file + ":" + line.to_s
-        end
+        file, line = method.source_location
+        file + ":" + line.to_s
       end
 
       def method_name(method)
@@ -34,8 +26,7 @@ module Contracts
       end
 
       def eigenclass_hierarchy_supported?
-        return false if RUBY_PLATFORM == "java" && RUBY_VERSION.to_f < 2.0
-        RUBY_VERSION.to_f > 1.8
+        RUBY_PLATFORM != "java" || RUBY_VERSION.to_f >= 2.0
       end
 
       def eigenclass_of(target)


### PR DESCRIPTION
As per the conversation in:

https://github.com/egonSchiele/contracts.ruby/pull/255