### PR TITLE
Apply contracts to each name for multi-attribute calls

### DIFF
--- a/lib/contracts/attrs.rb
+++ b/lib/contracts/attrs.rb
@@ -1,13 +1,17 @@
 module Contracts
   module Attrs
     def attr_reader_with_contract(*names, contract)
-      Contract Contracts::None => contract
-      attr_reader(*names)
+      names.each do |name|
+        Contract Contracts::None => contract
+        attr_reader(name)
+      end
     end
 
     def attr_writer_with_contract(*names, contract)
-      Contract contract => contract
-      attr_writer(*names)
+      names.each do |name|
+        Contract contract => contract
+        attr_writer(name)
+      end
     end
 
     def attr_accessor_with_contract(*names, contract)

--- a/spec/attrs_spec.rb
+++ b/spec/attrs_spec.rb
@@ -9,11 +9,15 @@ RSpec.describe "Contracts:" do
         @name_r = name
         @name_w = name
         @name_rw = name
+
+        @name_r_2 = name
+        @name_w_2 = name
+        @name_rw_2 = name
       end
 
-      attr_reader_with_contract :name_r, String
-      attr_writer_with_contract :name_w, String
-      attr_accessor_with_contract :name_rw, String
+      attr_reader_with_contract :name_r, :name_r_2, String
+      attr_writer_with_contract :name_w, :name_w_2, String
+      attr_accessor_with_contract :name_rw, :name_rw_2, String
     end
 
     context "attr_reader_with_contract" do
@@ -25,6 +29,16 @@ RSpec.describe "Contracts:" do
       it "getting invalid type" do
         expect { Person.new(1.3).name_r }
           .to(raise_error(ReturnContractError))
+      end
+
+      it "getting valid type for second val" do
+        expect(Person.new("bob").name_r_2)
+          .to(eq("bob"))
+      end
+
+      it "getting invalid type for second val" do
+        expect { Person.new(1.3).name_r_2 }
+        .to(raise_error(ReturnContractError))
       end
 
       it "setting" do
@@ -48,6 +62,16 @@ RSpec.describe "Contracts:" do
         expect { Person.new("bob").name_w = 1.2 }
           .to(raise_error(ParamContractError))
       end
+
+      it "setting valid type for second val" do
+        expect(Person.new("bob").name_w_2 = "alice")
+          .to(eq("alice"))
+      end
+
+      it "setting invalid type for second val" do
+        expect { Person.new("bob").name_w_2 = 1.2 }
+          .to(raise_error(ParamContractError))
+      end
     end
 
     context "attr_accessor_with_contract" do
@@ -68,6 +92,26 @@ RSpec.describe "Contracts:" do
 
       it "setting invalid type" do
         expect { Person.new("bob").name_rw = 1.2 }
+          .to(raise_error(ParamContractError))
+      end
+
+      it "getting valid type for second val" do
+        expect(Person.new("bob").name_rw_2)
+          .to(eq("bob"))
+      end
+
+      it "getting invalid type for second val" do
+        expect { Person.new(1.2).name_rw_2 }
+          .to(raise_error(ReturnContractError))
+      end
+
+      it "setting valid type for second val" do
+        expect(Person.new("bob").name_rw_2 = "alice")
+          .to(eq("alice"))
+      end
+
+      it "setting invalid type for second val" do
+        expect { Person.new("bob").name_rw_2 = 1.2 }
           .to(raise_error(ParamContractError))
       end
     end

--- a/spec/attrs_spec.rb
+++ b/spec/attrs_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "Contracts:" do
 
       it "getting invalid type for second val" do
         expect { Person.new(1.3).name_r_2 }
-        .to(raise_error(ReturnContractError))
+          .to(raise_error(ReturnContractError))
       end
 
       it "setting" do


### PR DESCRIPTION
:wave:

When passing in multiple fields to a single attr_x_with_contract call, the current implementation only applies the contract for the first field.

```ruby
class Thinger
  include Contracts
  include Contracts::Attrs

  attr_accessor_with_contract :a, :b, :c, String
end
```
```
[development] » t = Thinger.new
» #<Test:0x007f934f552dc0>
[development] » t.c
» nil
[development] » t.b
» nil
[development] » t.a
ReturnContractError: Contract violation for return value:
Expected: String,
        Actual: nil
        Value guarded in: Test::a
```

This applies the contract and attr_reader individually to each field.