### PR TITLE
Gemfile: use https RubyGems source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gemspec
 


### PR DESCRIPTION
This PR avoids the http endpoint, using the HTTPS one. 