### PR TITLE
Fix two tiny misspellings in comments

### DIFF
--- a/lib/contracts/call_with.rb
+++ b/lib/contracts/call_with.rb
@@ -74,7 +74,7 @@ module Contracts
                  # proc, block, lambda, etc
                  method.call(*args, &blk)
                else
-                 # original method name referrence
+                 # original method name reference
                  added_block = blk ? lambda { |*params| blk.call(*params) } : nil
                  method.send_to(this, *args, &added_block)
                end

--- a/spec/ruby_version_specific/contracts_spec_2.1.rb
+++ b/spec/ruby_version_specific/contracts_spec_2.1.rb
@@ -51,7 +51,7 @@ RSpec.describe "Contracts:" do
         end.to raise_error(ContractError)
       end
 
-      it "should fail when passed nil to an optional argument which contract shouldnt accept nil" do
+      it "should fail when passed nil to an optional argument which contract shouldn't accept nil" do
         expect do
           @o.complicated("a", true, :b, :c, 2.0, e: (1..5), f: nil, g: :d) do |x|
             x


### PR DESCRIPTION
This tiny PR fixes all (2) misspellings found by running the following command on the codebase:

```
find . | misspellings -f -
```

[misspellings](https://pypi.python.org/pypi/misspellings) is a Python program which:

> check[s] for misspelled words in source code. It does this by looking for words from a list of common misspellings. The dictionary it uses to do this is based on the Wikipedia list of common misspellings.