### PR TITLE
Fix typo in Contracts::MethodHandler#validate_decorators!

### DIFF
--- a/lib/contracts/method_handler.rb
+++ b/lib/contracts/method_handler.rb
@@ -157,7 +157,7 @@ module Contracts
       return if decorators.size == 1
 
       fail %{
-Oops, it looks like method '#{name}' has multiple contracts:
+Oops, it looks like method '#{method_name}' has multiple contracts:
 #{decorators.map { |x| x[1][0].inspect }.join("\n")}
 
 Did you accidentally put more than one contract on a single function, like so?


### PR DESCRIPTION
AFAICT, `name` is not defined at that point