### PR TITLE
RFC: Flags to turn off pattern matching and evaluation

### DIFF
--- a/lib/contracts/call_with.rb
+++ b/lib/contracts/call_with.rb
@@ -9,46 +9,12 @@ module Contracts
       # Explicitly append options={} if Hash contract is present
       maybe_append_options!(args, blk)
 
-      # Loop forward validating the arguments up to the splat (if there is one)
-      (@args_contract_index || args.size).times do |i|
-        contract = args_contracts[i]
-        arg = args[i]
-        validator = @args_validators[i]
-
-        unless validator && validator[arg]
-          return unless Contract.failure_callback(:arg => arg,
-                                                  :contract => contract,
-                                                  :class => klass,
-                                                  :method => method,
-                                                  :contracts => self,
-                                                  :arg_pos => i+1,
-                                                  :total_args => args.size,
-                                                  :return_value => false)
-        end
-
-        if contract.is_a?(Contracts::Func) && blk && !nil_block_appended
-          blk = Contract.new(klass, arg, *contract.contracts)
-        elsif contract.is_a?(Contracts::Func)
-          args[i] = Contract.new(klass, arg, *contract.contracts)
-        end
-      end
-
-      # If there is a splat loop backwards to the lower index of the splat
-      # Once we hit the splat in this direction set its upper index
-      # Keep validating but use this upper index to get the splat validator.
-      if @args_contract_index
-        splat_upper_index = @args_contract_index
-        (args.size - @args_contract_index).times do |i|
-          arg = args[args.size - 1 - i]
-
-          if args_contracts[args_contracts.size - 1 - i].is_a?(Contracts::Args)
-            splat_upper_index = i
-          end
-
-          # Each arg after the spat is found must use the splat validator
-          j = i < splat_upper_index ? i : splat_upper_index
-          contract = args_contracts[args_contracts.size - 1 - j]
-          validator = @args_validators[args_contracts.size - 1 - j]
+      if Support.validation_enabled?
+        # Loop forward validating the arguments up to the splat (if there is one)
+        (@args_contract_index || args.size).times do |i|
+          contract = args_contracts[i]
+          arg = args[i]
+          validator = @args_validators[i]
 
           unless validator && validator[arg]
             return unless Contract.failure_callback(:arg => arg,
@@ -56,13 +22,49 @@ module Contracts
                                                     :class => klass,
                                                     :method => method,
                                                     :contracts => self,
-                                                    :arg_pos => i-1,
+                                                    :arg_pos => i+1,
                                                     :total_args => args.size,
                                                     :return_value => false)
           end
 
-          if contract.is_a?(Contracts::Func)
-            args[args.size - 1 - i] = Contract.new(klass, arg, *contract.contracts)
+          if contract.is_a?(Contracts::Func) && blk && !nil_block_appended
+            blk = Contract.new(klass, arg, *contract.contracts)
+          elsif contract.is_a?(Contracts::Func)
+            args[i] = Contract.new(klass, arg, *contract.contracts)
+          end
+        end
+
+        # If there is a splat loop backwards to the lower index of the splat
+        # Once we hit the splat in this direction set its upper index
+        # Keep validating but use this upper index to get the splat validator.
+        if @args_contract_index
+          splat_upper_index = @args_contract_index
+          (args.size - @args_contract_index).times do |i|
+            arg = args[args.size - 1 - i]
+
+            if args_contracts[args_contracts.size - 1 - i].is_a?(Contracts::Args)
+              splat_upper_index = i
+            end
+
+            # Each arg after the spat is found must use the splat validator
+            j = i < splat_upper_index ? i : splat_upper_index
+            contract = args_contracts[args_contracts.size - 1 - j]
+            validator = @args_validators[args_contracts.size - 1 - j]
+
+            unless validator && validator[arg]
+              return unless Contract.failure_callback(:arg => arg,
+                                                      :contract => contract,
+                                                      :class => klass,
+                                                      :method => method,
+                                                      :contracts => self,
+                                                      :arg_pos => i-1,
+                                                      :total_args => args.size,
+                                                      :return_value => false)
+            end
+
+            if contract.is_a?(Contracts::Func)
+              args[args.size - 1 - i] = Contract.new(klass, arg, *contract.contracts)
+            end
           end
         end
       end
@@ -79,19 +81,21 @@ module Contracts
                  method.send_to(this, *args, &added_block)
                end
 
-      unless @ret_validator[result]
-        Contract.failure_callback(:arg => result,
-                                  :contract => ret_contract,
-                                  :class => klass,
-                                  :method => method,
-                                  :contracts => self,
-                                  :return_value => true)
-      end
+      if Support.validation_enabled?
+        unless @ret_validator[result]
+          Contract.failure_callback(:arg => result,
+                                    :contract => ret_contract,
+                                    :class => klass,
+                                    :method => method,
+                                    :contracts => self,
+                                    :return_value => true)
+        end
 
-      this.verify_invariants!(method) if this.respond_to?(:verify_invariants!)
+        this.verify_invariants!(method) if this.respond_to?(:verify_invariants!)
 
-      if ret_contract.is_a?(Contracts::Func)
-        result = Contract.new(klass, result, *ret_contract.contracts)
+        if ret_contract.is_a?(Contracts::Func)
+          result = Contract.new(klass, result, *ret_contract.contracts)
+        end
       end
 
       result

--- a/lib/contracts/engine/base.rb
+++ b/lib/contracts/engine/base.rb
@@ -80,8 +80,12 @@ module Contracts
       # @param [Symbol] name - method name
       # @param [Decorator] decorator - method decorator
       def add_method_decorator(type, name, decorator)
-        decorated_methods[type][name] ||= []
-        decorated_methods[type][name] << decorator
+        if Support.pattern_matching_enabled?
+          decorated_methods[type][name] ||= []
+          decorated_methods[type][name] << decorator
+        else
+          decorated_methods[type][name] = [decorator]
+        end
       end
 
       # Returns nearest ancestor's engine that has decorated methods
@@ -109,8 +113,7 @@ module Contracts
       end
 
       # No-op because it is safe to add decorators to normal classes
-      def validate!
-      end
+      def validate!; end
 
       def pop_decorators
         decorators.tap { clear_decorators }

--- a/lib/contracts/invariants.rb
+++ b/lib/contracts/invariants.rb
@@ -24,7 +24,7 @@ module Contracts
 
     module InvariantExtension
       def invariant(name, &condition)
-        return if ENV["NO_CONTRACTS"]
+        return unless Support.invariants_enabled?
 
         invariants << Invariant.new(self, name, &condition)
       end

--- a/lib/contracts/method_handler.rb
+++ b/lib/contracts/method_handler.rb
@@ -69,7 +69,7 @@ module Contracts
     end
 
     def ignore_decorators?
-      ENV["NO_CONTRACTS"] && !pattern_matching?
+      !Support.decorators_enabled? && !pattern_matching?
     end
 
     def decorated_methods
@@ -77,8 +77,8 @@ module Contracts
     end
 
     def pattern_matching?
-      return @_pattern_matching if defined?(@_pattern_matching)
-      @_pattern_matching = decorated_methods.any? { |x| x.method != method_reference }
+      return false unless Support.pattern_matching_enabled?
+      @_pattern_matching ||= decorated_methods.any? { |x| x.method != method_reference }
     end
 
     def mark_pattern_matching_decorators
@@ -154,6 +154,7 @@ module Contracts
     end
 
     def validate_decorators!
+      return unless Support.decorators_enabled?
       return if decorators.size == 1
 
       fail %{
@@ -174,6 +175,8 @@ https://github.com/egonSchiele/contracts.ruby/issues
     end
 
     def validate_pattern_matching!
+      return unless Support.pattern_matching_enabled?
+
       new_args_contract = decorator.args_contracts
       matched = decorated_methods.select do |contract|
         contract.args_contracts == new_args_contract

--- a/lib/contracts/support.rb
+++ b/lib/contracts/support.rb
@@ -12,6 +12,22 @@ module Contracts
         end
       end
 
+      def decorators_enabled?
+        !ENV["NO_CONTRACTS"]
+      end
+
+      def invariants_enabled?
+        !ENV["NO_CONTRACTS"]
+      end
+
+      def pattern_matching_enabled?
+        !ENV["NO_CONTRACTS_PATTERN_MATCHING"]
+      end
+
+      def validation_enabled?
+        !ENV["NO_CONTRACTS_VALIDATION"]
+      end
+
       def method_name(method)
         method.is_a?(Proc) ? "Proc" : method.name
       end


### PR DESCRIPTION
We'd like to be able to turn off the pattern matching/method overloading behavior altogether -- it can lead to unpleasant surprises, and we don't want someone inadvertently writing code that relies on it in our environment.

Similarly, I think it'd be valuable to have a feature that allows selective disabling of *validation* of contracts after having loaded them. (The idea being, it might permit running contracts in non-perf-sensitive codepaths in production or a fraction of prod requests)

I've sketched a version of how I thought this might work to get some feedback from you about

a) is this likely to get merged if completed?
b) is this a reasonable approach?
c) any big pitfalls that I'm not thinking of

I haven't tested this very much at all, will proceed to do so if you think this is a good direction to pursue.