### PR TITLE
Wrapping &blocks only when there is a Func check. (second version) (bug 278)

### DIFF
--- a/lib/contracts/call_with.rb
+++ b/lib/contracts/call_with.rb
@@ -81,8 +81,10 @@ module Contracts
                  method.call(*args, &blk)
                else
                  # original method name reference
-                 added_block = blk ? lambda { |*params| blk.call(*params) } : nil
-                 method.send_to(this, *args, &added_block)
+                 # Don't reassign blk, else Travis CI shows "stack level too deep".
+                 target_blk = blk
+                 target_blk = lambda { |*params| blk.call(*params) } if blk && blk.is_a?(Contract)
+                 method.send_to(this, *args, &target_blk)
                end
 
       unless @ret_validator[result]


### PR DESCRIPTION
See https://github.com/egonSchiele/contracts.ruby/issues/278#issuecomment-351428779 and https://github.com/egonSchiele/contracts.ruby/pull/281#issuecomment-362851436

Somehow Travis CI didn't like that I reasigned the blk variable. So I introduced a new target_blk variable.