### PR TITLE
Create GitHub Workflow config to simulate Travis builds

### DIFF
--- a/.github/workflows/code_style_checks.yaml
+++ b/.github/workflows/code_style_checks.yaml
@@ -1,0 +1,36 @@
+name: Code Style Checks
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - 'README.md'
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'README.md'
+
+jobs:
+  rubocop:
+    name: Rubocop
+    if: "contains(github.event.commits[0].message, '[ci skip]') == false"
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu
+        ruby:
+          - "jruby"
+    runs-on: ${{ matrix.os }}-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Run Rubocop
+        run: bundle exec rubocop

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,50 @@
+name: Tests
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - 'README.md'
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'README.md'
+
+jobs:
+  unit_tests:
+    name: Unit Tests
+    if: "contains(github.event.commits[0].message, '[ci skip]') == false"
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu
+        ruby:
+          - "1.9.2"
+          - "1.9.3"
+          - "2.0"
+          - "2.1"
+          - "2.2"
+          - "2.3"
+          - "2.4"
+          - "2.5"
+          - "2.6"
+          - "2.7"
+        test_command: ["bundle exec rspec && bundle exec cucumber"]
+        include:
+          - os: ubuntu
+            ruby: "2.4.2"
+            test_command: "bundle exec rspec"
+    runs-on: ${{ matrix.os }}-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Test
+        run: ${{ test_command }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.swp
 *.swo
 .*
+!.github
 Gemfile.lock
 tmp/aruba


### PR DESCRIPTION
https://www.reddit.com/r/ruby/comments/jt2uub/deep_dive_moving_ruby_projects_from_travis_to/

Travis will no longer be free for Open Source projects (And it's already slow for OS projects now)
This is to move to GitHub Action for CI

Same Ruby versions plus 2.6-2.7
JRuby still used for code style checks but different version due to what [`ruby/setup-ruby` action](https://github.com/ruby/setup-ruby) supports

Old Ruby versions might fail