### PR TITLE
Add Ruby 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,6 +22,7 @@ jobs:
         os:
           - ubuntu
         ruby:
+          - "3.1"
           - "3.0"
         test_command:
           - "bundle exec rspec && bundle exec cucumber"


### PR DESCRIPTION
This PR just adds Ruby 3.1 to the CI matrix.

As a side note, there's an `include` in the config that I don't think is necessary.  The specs run twice for Ruby 3.0 - once with both rspec and cucumber, and then one with rspec only.  The latter is the result of the include, which I believe can be removed.