### PR TITLE
Always load version.rb, suppress legacy deprecation warning

### DIFF
--- a/contracts.gemspec
+++ b/contracts.gemspec
@@ -13,8 +13,4 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/egonSchiele/contracts.ruby"
   s.license     = "BSD-2-Clause"
   s.required_ruby_version = [">= 3.0", "< 4"]
-  s.post_install_message = "
-    0.16.x will be the supporting Ruby 2.x and be feature frozen (only fixes will be released)
-    For Ruby 3.x use 0.17.x or later
-  "
 end

--- a/lib/contracts.rb
+++ b/lib/contracts.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "contracts/version"
 require "contracts/attrs"
 require "contracts/builtin_contracts"
 require "contracts/decorators"


### PR DESCRIPTION
Two minor improvements:

1. Automatically load `version.rb`, so that `Contracts::VERSION` is always accessible to user
2. Hide the gem deprecation warning if the user is already on the latest version