### PR TITLE
Relax `required_ruby_version` to support Ruby 4.0

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,6 +29,7 @@ jobs:
           - "3.2"
           - "3.3"
           - "3.4"
+          - "4.0"
         allow_failures:
           - false
         include:

--- a/contracts.gemspec
+++ b/contracts.gemspec
@@ -12,5 +12,5 @@ Gem::Specification.new do |s|
   s.files       = `git ls-files`.split("\n")
   s.homepage    = "https://github.com/egonSchiele/contracts.ruby"
   s.license     = "BSD-2-Clause"
-  s.required_ruby_version = [">= 3.0", "< 4"]
+  s.required_ruby_version = [">= 3.0", "< 5"]
 end


### PR DESCRIPTION
This Pull Request relaxed the `required_ruby_version` to allow Ruby 4.0.

The current gemspec specifies an upper bound of `< 4`, which prevents `gem install contracts` from working on Ruby 4.0, scheduled for release on December 25.
By removing this upper bound, the gem will continue to work on Ruby 4.0 and future Ruby versions.

- Ruby 4.0.0 preview2 Released
  - https://www.ruby-lang.org/en/news/2025/11/17/ruby-4-0-0-preview2-released/


### Additional Information

All tests pass on my local environment using Ruby 4.0-dev.

```sh
$ ruby -v
ruby 4.0.0dev (2025-11-28T10:49:46Z master dcb9e17f46) +PRISM [arm64-darwin25]

$ bundle exec rake spec
...
Finished in 0.06349 seconds (files took 0.0736 seconds to load)
231 examples, 0 failures

$ bundle exec rake cucumber
...
85 scenarios (1 undefined, 84 passed)
372 steps (372 passed)
0m9.122s
```
